### PR TITLE
feat: add defaults updates and command-based onboarding

### DIFF
--- a/.changeset/fuzzy-snails-worry.md
+++ b/.changeset/fuzzy-snails-worry.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Fix home-directory default policy rules so `~`-based patterns match correctly and expand to the current user's home directory during blocking and existence checks.

--- a/.changeset/tough-bees-rescue.md
+++ b/.changeset/tough-bees-rescue.md
@@ -1,0 +1,10 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add command-based onboarding for new users.
+
+- add `/guardrails:onboarding` command and session-start hint when setup is pending
+- replace auto-open onboarding with explicit overlay flow
+- add onboarding completion marker for config compatibility and first-run state
+- improve onboarding wizard copy and defaults/recap UX

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ src/
 - `config.version` is a schema marker for debugging/inspection, not the package version
 - Events emitted on the pi event bus for inter-extension communication (`guardrails:blocked`, `guardrails:dangerous`)
 
+## Documentation
+
+When adding, updating, or removing default policy rules, default permission gate patterns, or example presets, you must also update the corresponding documentation files:
+
+- [`docs/defaults.md`](docs/defaults.md) — mirrors `DEFAULT_CONFIG` in `src/config.ts`
+- [`docs/examples.md`](docs/examples.md) — mirrors `POLICY_EXAMPLES` and `COMMAND_EXAMPLES` in `src/commands/settings-command.ts`
+
 ## Versioning
 
 Uses changesets. Run `pnpm changeset` before committing user-facing changes.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Or from git:
 pi install git:github.com/aliou/pi-guardrails
 ```
 
+## Documentation
+
+- [Default configuration](docs/defaults.md) — built-in policy rules and permission gate patterns
+- [Example presets](docs/examples.md) — pre-configured presets available in settings
+
 ## What it does
 
 - **policies**: named file-protection rules with per-rule protection levels.

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -1,0 +1,115 @@
+# Default Configuration
+
+These are the built-in defaults that ship with guardrails. Rules marked as disabled are included but inactive by default — enable them in your config or via `/guardrails:settings`.
+
+Source: [`src/config.ts`](../src/config.ts)
+
+
+Home-directory defaults use `~` in patterns. During policy evaluation, guardrails expands `~` to the current user's home directory before checking whether a file exists or should be blocked.
+## Default Policy Rules
+
+### `secret-files` — Files containing secrets
+
+Blocks access to dotenv files and similar secret-bearing files.
+
+| Protection | Only if exists |
+|------------|---------------|
+| `noAccess` | yes           |
+
+**Patterns:**
+
+| Pattern            | Type |
+|--------------------|------|
+| `.env`             | glob |
+| `.env.local`       | glob |
+| `.env.production`  | glob |
+| `.env.prod`        | glob |
+| `.dev.vars`        | glob |
+
+**Allowed exceptions:**
+
+| Pattern            | Type |
+|--------------------|------|
+| `*.example.env`    | glob |
+| `*.sample.env`     | glob |
+| `*.test.env`       | glob |
+| `.env.example`     | glob |
+| `.env.sample`      | glob |
+| `.env.test`        | glob |
+
+---
+
+### `home-ssh` — SSH directory and keys
+
+Blocks access to SSH configuration, private keys, and related files. Disabled by default.
+
+| Protection | Only if exists | Enabled by default |
+|------------|---------------|-------------------|
+| `noAccess` | yes           | no                |
+
+**Patterns:**
+
+| Pattern               | Type |
+|-----------------------|------|
+| `~/.ssh/**`          | glob |
+| `~/.ssh/*_rsa`       | glob |
+| `~/.ssh/*_ed25519`   | glob |
+| `~/.ssh/*.pem`       | glob |
+
+**Allowed exceptions:**
+
+| Pattern  | Type |
+|----------|------|
+| `~/.ssh/*.pub` | glob |
+
+---
+
+### `home-config` — Sensitive user configuration directories
+
+Blocks access to a small set of known sensitive config directories that commonly store credentials, tokens, or encrypted material. Disabled by default — enable it if these tools are installed and you want to protect them.
+
+| Protection | Only if exists | Enabled by default |
+|------------|---------------|-------------------|
+| `noAccess` | yes           | no                |
+
+**Patterns:**
+
+| Pattern               | Type |
+|-----------------------|------|
+| `~/.config/gh/**`     | glob |
+| `~/.config/gcloud/**` | glob |
+| `~/.config/op/**`     | glob |
+| `~/.config/sops/**`   | glob |
+
+---
+
+### `home-gpg` — GPG keys and configuration
+
+Blocks access to GPG/GnuPG private keys, keyrings, and configuration. Disabled by default.
+
+| Protection | Only if exists | Enabled by default |
+|------------|---------------|-------------------|
+| `noAccess` | yes           | no                |
+
+**Patterns:**
+
+| Pattern            | Type |
+|--------------------|------|
+| `~/.gnupg/**`       | glob |
+| `~/*.gpg`           | glob |
+| `~/.gpg-agent.conf` | glob |
+
+---
+
+## Default Permission Gate Patterns
+
+These commands are detected using AST-based structural matching for accuracy.
+
+| Pattern         | Description                    |
+|-----------------|--------------------------------|
+| `rm -rf`        | Recursive force delete         |
+| `sudo`          | Superuser command              |
+| `dd if=`        | Disk write operation           |
+| `mkfs.`         | Filesystem format              |
+| `chmod -R 777`  | Insecure recursive permissions |
+| `chown -R`      | Recursive ownership change     |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,170 @@
+# Example Presets
+
+Pre-configured presets available in the `/guardrails:settings` Examples tab. These can be applied to any config scope (global, local, or memory).
+
+Source: [`src/commands/settings-command.ts`](../src/commands/settings-command.ts)
+
+## File Policy Presets
+
+### Secrets (.env)
+
+Block dotenv-like files using glob patterns.
+
+| Field      | Value                              |
+|------------|------------------------------------|
+| ID         | `example-secret-env-files`         |
+| Protection | `noAccess`                         |
+| Patterns   | `.env`, `.env.*`                   |
+| Exceptions | `.env.example`, `*.sample.env`     |
+
+---
+
+### Logs (*.log)
+
+Mark log files as read-only to prevent accidental modification.
+
+| Field      | Value                     |
+|------------|---------------------------|
+| ID         | `example-log-files`       |
+| Protection | `readOnly`                |
+| Patterns   | `*.log`, `*.out`          |
+
+---
+
+### Regex env
+
+Regex-based matching for `.env` and `.env.*` files. Demonstrates regex mode.
+
+| Field      | Value                                    |
+|------------|------------------------------------------|
+| ID         | `example-regex-env`                      |
+| Protection | `noAccess`                               |
+| Patterns   | `^\.env(\..+)?$` (regex)                 |
+| Exceptions | `^\.env\.example$` (regex)               |
+
+---
+
+### SSH keys
+
+Block access to SSH private key files.
+
+| Field      | Value                                |
+|------------|--------------------------------------|
+| ID         | `example-ssh-keys`                   |
+| Protection | `noAccess`                           |
+| Patterns   | `*.pem`, `*_rsa`, `*_ed25519`       |
+| Exceptions | `*.pub`                              |
+
+---
+
+### AWS credentials
+
+Block AWS CLI credentials and config files.
+
+| Field      | Value                                  |
+|------------|----------------------------------------|
+| ID         | `example-aws-credentials`              |
+| Protection | `noAccess`                             |
+| Patterns   | `.aws/credentials`, `.aws/config`      |
+
+---
+
+### Database files
+
+Mark SQLite and database files as read-only.
+
+| Field      | Value                                  |
+|------------|----------------------------------------|
+| ID         | `example-database-files`               |
+| Protection | `readOnly`                             |
+| Patterns   | `*.db`, `*.sqlite`, `*.sqlite3`        |
+
+---
+
+### Kubernetes secrets
+
+Block kubeconfig and Kubernetes secret files.
+
+| Field      | Value                                  |
+|------------|----------------------------------------|
+| ID         | `example-k8s-secrets`                  |
+| Protection | `noAccess`                             |
+| Patterns   | `.kube/config`, `*kubeconfig*`         |
+
+---
+
+### Certificates
+
+Block SSL/TLS certificate and key files.
+
+| Field      | Value                                  |
+|------------|----------------------------------------|
+| ID         | `example-certificates`                 |
+| Protection | `noAccess`                             |
+| Patterns   | `*.crt`, `*.key`, `*.p12`              |
+| Exceptions | `*.csr`                                |
+
+---
+
+## Dangerous Command Presets
+
+### General
+
+| Label              | Pattern              | Description                            |
+|--------------------|----------------------|----------------------------------------|
+| Homebrew           | `brew`               | Homebrew package manager               |
+| git push --force   | `git push --force`   | Git force push                         |
+| npm publish        | `npm publish`        | NPM package publishing                 |
+| yarn publish       | `yarn publish`       | Yarn package publishing                |
+| pnpm publish       | `pnpm publish`       | PNPM package publishing                |
+| drop database      | `DROP DATABASE`      | SQL database drop                      |
+| drop table         | `DROP TABLE`         | SQL table drop                         |
+
+### dbt
+
+| Label    | Pattern    | Description            |
+|----------|------------|------------------------|
+| dbt run  | `dbt run`  | dbt model execution    |
+| dbt seed | `dbt seed` | dbt seed data loading  |
+
+### AWS
+
+| Label                | Pattern                        | Description                  |
+|----------------------|--------------------------------|------------------------------|
+| aws s3 rm            | `aws s3 rm`                    | AWS S3 object deletion       |
+| aws iam              | `aws iam`                      | AWS IAM permission changes   |
+| aws ec2 terminate    | `aws ec2 terminate-instances`  | AWS EC2 instance termination |
+
+### Kubernetes
+
+| Label          | Pattern          | Description                    |
+|----------------|------------------|--------------------------------|
+| kubectl delete | `kubectl delete` | Kubernetes resource deletion   |
+| kubectl apply  | `kubectl apply`  | Kubernetes resource application|
+| kubectl scale  | `kubectl scale`  | Kubernetes scaling operation   |
+
+### Docker
+
+| Label                | Pattern                | Description                              |
+|----------------------|------------------------|------------------------------------------|
+| Docker secrets       | `docker inspect`       | Docker inspect (may expose env vars)     |
+| docker rm            | `docker rm`            | Docker container removal                 |
+| docker rmi           | `docker rmi`           | Docker image removal                     |
+| docker system prune  | `docker system prune`  | Docker system cleanup                    |
+| docker compose down  | `docker compose down`  | Docker Compose service teardown          |
+
+### Terraform
+
+| Label              | Pattern              | Description                        |
+|--------------------|----------------------|------------------------------------|
+| Terraform apply    | `terraform apply`    | Terraform infrastructure changes   |
+| Terraform destroy  | `terraform destroy`  | Terraform infrastructure destruction|
+| terraform import   | `terraform import`   | Terraform resource import          |
+
+### Google Cloud
+
+| Label                  | Pattern                            | Description                      |
+|------------------------|------------------------------------|----------------------------------|
+| gcloud compute delete  | `gcloud compute instances delete`  | GCP compute instance deletion    |
+| gcloud iam             | `gcloud iam`                       | GCP IAM permission changes       |
+| gcloud sql delete      | `gcloud sql instances delete`      | GCP Cloud SQL instance deletion  |

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aliou/pi-utils-settings": "^0.10.1",
+    "@aliou/pi-utils-settings": "^0.10.2",
     "@aliou/sh": "^0.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "src",
+    "docs",
     "README.md"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aliou/pi-utils-settings": "^0.10.2",
+    "@aliou/pi-utils-settings": "^0.11.2",
     "@aliou/sh": "^0.1.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@aliou/pi-utils-settings':
-        specifier: ^0.10.1
-        version: 0.10.1(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))
+        specifier: ^0.10.2
+        version: 0.10.2(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))
       '@aliou/sh':
         specifier: ^0.1.0
         version: 0.1.0
@@ -60,10 +60,10 @@ packages:
     peerDependencies:
       '@biomejs/biome': '>=2.0.0'
 
-  '@aliou/pi-utils-settings@0.10.1':
-    resolution: {integrity: sha512-3BkAtQ1vQg7nstXYXOi9wK7ElIc/eOAfAXgmQbpMyOts8XkAzwVvjxsT+A9aMo3oj7JVSOoP+EBP691VNpQXZA==}
+  '@aliou/pi-utils-settings@0.10.2':
+    resolution: {integrity: sha512-Jd5k+WF4/QAzP7rzxJfMMqBkDexQXyYNXGxk9Gu0WePDR/wK5jjMgivh9Beg3mNoY2NgAyNwGPCtYk0XUMPE4g==}
     peerDependencies:
-      '@mariozechner/pi-coding-agent': '>=0.51.0'
+      '@mariozechner/pi-coding-agent': 0.61.0
     peerDependenciesMeta:
       '@mariozechner/pi-coding-agent':
         optional: true
@@ -1602,7 +1602,7 @@ snapshots:
     dependencies:
       '@biomejs/biome': 2.4.2
 
-  '@aliou/pi-utils-settings@0.10.1(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))':
+  '@aliou/pi-utils-settings@0.10.2(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))':
     optionalDependencies:
       '@mariozechner/pi-coding-agent': 0.61.0(ws@8.19.0)(zod@3.25.76)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@aliou/pi-utils-settings':
-        specifier: ^0.10.2
-        version: 0.10.2(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))
+        specifier: ^0.11.2
+        version: 0.11.2(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))
       '@aliou/sh':
         specifier: ^0.1.0
         version: 0.1.0
@@ -60,10 +60,10 @@ packages:
     peerDependencies:
       '@biomejs/biome': '>=2.0.0'
 
-  '@aliou/pi-utils-settings@0.10.2':
-    resolution: {integrity: sha512-Jd5k+WF4/QAzP7rzxJfMMqBkDexQXyYNXGxk9Gu0WePDR/wK5jjMgivh9Beg3mNoY2NgAyNwGPCtYk0XUMPE4g==}
+  '@aliou/pi-utils-settings@0.11.2':
+    resolution: {integrity: sha512-9wacnpEnDsjOw9v7j54yu9d6iNWgWapkM8NphTLMoXrFxonDtNiYS3t7Z+g1uSSEibQxrZxpauzJcDsqkEXwEA==}
     peerDependencies:
-      '@mariozechner/pi-coding-agent': 0.61.0
+      '@mariozechner/pi-coding-agent': '>=0.61.0 <1'
     peerDependenciesMeta:
       '@mariozechner/pi-coding-agent':
         optional: true
@@ -1602,7 +1602,7 @@ snapshots:
     dependencies:
       '@biomejs/biome': 2.4.2
 
-  '@aliou/pi-utils-settings@0.10.2(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))':
+  '@aliou/pi-utils-settings@0.11.2(@mariozechner/pi-coding-agent@0.61.0(ws@8.19.0)(zod@3.25.76))':
     optionalDependencies:
       '@mariozechner/pi-coding-agent': 0.61.0(ws@8.19.0)(zod@3.25.76)
 

--- a/src/commands/onboarding-command.ts
+++ b/src/commands/onboarding-command.ts
@@ -1,0 +1,59 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { configLoader, type GuardrailsConfig } from "../config";
+import {
+  buildOnboardedConfig,
+  createOnboardingWizard,
+  isOnboardingPending,
+  type OnboardingResult,
+} from "./onboarding";
+
+function mergeOnboarding(
+  base: GuardrailsConfig | null,
+  applyBuiltinDefaults: boolean,
+): GuardrailsConfig {
+  const next = structuredClone(base ?? {});
+  const onboarded = buildOnboardedConfig(applyBuiltinDefaults);
+  next.applyBuiltinDefaults = onboarded.applyBuiltinDefaults;
+  next.version = onboarded.version;
+  next.onboarding = onboarded.onboarding;
+  return next;
+}
+
+export function registerGuardrailsOnboardingCommand(
+  pi: ExtensionAPI,
+  onCompleted?: () => void,
+): void {
+  pi.registerCommand("guardrails:onboarding", {
+    description: "Run guardrails onboarding",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) return;
+
+      const globalConfig = configLoader.getRawConfig("global");
+      if (!isOnboardingPending(globalConfig)) {
+        ctx.ui.notify(
+          "[Guardrails] onboarding already completed. Use /guardrails:settings to update behavior.",
+          "info",
+        );
+        return;
+      }
+
+      const result = await ctx.ui.custom<OnboardingResult>(
+        (_tui, theme, _keybindings, done) =>
+          createOnboardingWizard(theme, done),
+        { overlay: true },
+      );
+
+      if (!result.completed || result.applyBuiltinDefaults === null) {
+        ctx.ui.notify("[Guardrails] onboarding cancelled.", "warning");
+        return;
+      }
+
+      const merged = mergeOnboarding(globalConfig, result.applyBuiltinDefaults);
+      await configLoader.save("global", merged);
+      await configLoader.load();
+
+      onCompleted?.();
+      ctx.ui.notify("[Guardrails] onboarding completed.", "info");
+    },
+  });
+}

--- a/src/commands/onboarding.ts
+++ b/src/commands/onboarding.ts
@@ -1,0 +1,274 @@
+import {
+  getSettingsTheme,
+  type SettingsTheme,
+  Wizard,
+} from "@aliou/pi-utils-settings";
+import { getMarkdownTheme, type Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import { Box, Key, Markdown, matchesKey, Text } from "@mariozechner/pi-tui";
+import type { GuardrailsConfig } from "../config";
+import { CURRENT_VERSION } from "../utils/migration";
+
+interface OnboardingState {
+  applyBuiltinDefaults: boolean | null;
+}
+
+export interface OnboardingResult {
+  completed: boolean;
+  applyBuiltinDefaults: boolean | null;
+}
+
+class IntroStep implements Component {
+  private readonly introText = new Text("", 2, 0);
+
+  constructor(private readonly onNext: () => void) {}
+
+  invalidate() {
+    this.introText.invalidate();
+  }
+
+  render(width: number): string[] {
+    this.introText.setText(
+      "Guardrails helps prevent accidental exposure of secrets and risky actions.\n\nIt gives you two protections:\n- Policies: file access rules (`noAccess` or `readOnly`)\n- Permission gate: confirmation before dangerous commands run\n\nYou are choosing the starting defaults now. You can change them later in `/guardrails:settings`.",
+    );
+
+    return [
+      "  Welcome to Guardrails",
+      "",
+      ...this.introText.render(Math.max(1, width)),
+    ];
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.enter)) {
+      this.onNext();
+    }
+  }
+}
+
+class DefaultsChoiceStep implements Component {
+  private selectedIndex = 0;
+  private readonly settingsTheme: SettingsTheme;
+
+  constructor(
+    private readonly theme: Theme,
+    private readonly state: OnboardingState,
+    private readonly onSelect: () => void,
+  ) {
+    this.settingsTheme = getSettingsTheme(theme);
+  }
+
+  invalidate() {}
+
+  render(width: number): string[] {
+    const options = ["Recommended defaults", "Minimal setup"];
+    const explanations = [
+      [
+        "Use built-ins for common safety needs:",
+        "",
+        "- Protect secret files like `.env`, `.env.local`, `.env.production`, and `.dev.vars`",
+        "- Keep safe exceptions like `.env.example` and `*.sample.env`",
+        "- Require confirmation before running dangerous commands like `rm -rf`, `sudo`, and `dd if=`",
+      ].join("\n"),
+      [
+        "Start with no built-in file policy defaults.",
+        "",
+        "- Configure your own policies in `/guardrails:settings`",
+        "- Browse policy and command examples in `/guardrails:settings`",
+      ].join("\n"),
+    ];
+
+    const lines: string[] = [
+      "  Pick how much built-in protection to start with.",
+      "",
+    ];
+
+    for (let i = 0; i < options.length; i++) {
+      const option = options[i];
+      if (!option) continue;
+      const selected = i === this.selectedIndex;
+      const prefix = selected ? this.settingsTheme.cursor : "  ";
+      const label = this.settingsTheme.value(` ${option}`, selected);
+      lines.push(`${prefix}${label}`);
+    }
+
+    lines.push("");
+
+    const explanationBox = new Box(1, 0, (s: string) => s);
+    explanationBox.addChild(
+      new Markdown(
+        explanations[this.selectedIndex] ?? "",
+        0,
+        0,
+        getMarkdownTheme(),
+        {
+          color: (s: string) => this.theme.fg("text", s),
+        },
+      ),
+    );
+
+    lines.push(...explanationBox.render(Math.max(1, width)));
+
+    return lines;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.up) || data === "k") {
+      this.selectedIndex = this.selectedIndex === 0 ? 1 : 0;
+      return;
+    }
+    if (matchesKey(data, Key.down) || data === "j") {
+      this.selectedIndex = this.selectedIndex === 1 ? 0 : 1;
+      return;
+    }
+
+    if (matchesKey(data, Key.enter)) {
+      this.state.applyBuiltinDefaults = this.selectedIndex === 0;
+      this.onSelect();
+    }
+  }
+}
+
+class FinishStep implements Component {
+  private readonly recapMarkdown = new Markdown("", 2, 0, getMarkdownTheme());
+
+  constructor(
+    private readonly state: OnboardingState,
+    private readonly onFinish: () => void,
+  ) {}
+
+  invalidate() {
+    this.recapMarkdown.invalidate();
+  }
+
+  render(width: number): string[] {
+    const content =
+      this.state.applyBuiltinDefaults === true
+        ? [
+            "You selected **Recommended defaults**.",
+            "",
+            "Guardrails will start with built-in protection, including:",
+            "- secret files like `.env`, `.env.local`, `.env.production`, `.dev.vars`",
+            "- safe exceptions like `.env.example` and `*.sample.env`",
+            "- confirmation before running dangerous commands like `rm -rf`, `sudo`, `dd if=`",
+          ].join("\n")
+        : [
+            "You selected **Minimal setup**.",
+            "",
+            "No built-in file policy defaults will be applied.",
+            "",
+            "You can configure policies later with `/guardrails:settings`.",
+          ].join("\n");
+
+    this.recapMarkdown.setText(content);
+    return [...this.recapMarkdown.render(Math.max(1, width)), ""];
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.enter)) {
+      this.onFinish();
+    }
+  }
+}
+
+export function createOnboardingWizard(
+  theme: Theme,
+  done: (result: OnboardingResult) => void,
+): Component {
+  const state: OnboardingState = {
+    applyBuiltinDefaults: null,
+  };
+
+  let markWelcomeComplete: (() => void) | null = null;
+  let settled = false;
+
+  const finalize = (result: OnboardingResult) => {
+    if (settled) return;
+    settled = true;
+    done(result);
+  };
+
+  const wizard = new Wizard({
+    title: "Guardrails onboarding",
+    theme,
+    steps: [
+      {
+        label: "Welcome",
+        build: (ctx) => {
+          markWelcomeComplete = ctx.markComplete;
+          return new IntroStep(() => {
+            ctx.markComplete();
+            ctx.goNext();
+          });
+        },
+      },
+      {
+        label: "Defaults",
+        build: (ctx) =>
+          new DefaultsChoiceStep(theme, state, () => {
+            ctx.markComplete();
+            ctx.goNext();
+          }),
+      },
+      {
+        label: "Recap",
+        build: (ctx) =>
+          new FinishStep(state, () => {
+            if (state.applyBuiltinDefaults === null) return;
+            ctx.markComplete();
+            finalize({
+              completed: true,
+              applyBuiltinDefaults: state.applyBuiltinDefaults,
+            });
+          }),
+      },
+    ],
+    onComplete: () => {
+      if (state.applyBuiltinDefaults === null) {
+        finalize({ completed: false, applyBuiltinDefaults: null });
+        return;
+      }
+      finalize({
+        completed: true,
+        applyBuiltinDefaults: state.applyBuiltinDefaults,
+      });
+    },
+    onCancel: () => finalize({ completed: false, applyBuiltinDefaults: null }),
+    hintSuffix: "Enter select/continue",
+    minContentHeight: 12,
+  });
+
+  return {
+    render: (width) => wizard.render(width),
+    invalidate: () => wizard.invalidate(),
+    handleInput: (data: string) => {
+      if (
+        matchesKey(data, Key.tab) &&
+        wizard.getActiveIndex() === 0 &&
+        markWelcomeComplete
+      ) {
+        markWelcomeComplete();
+      }
+      wizard.handleInput(data);
+    },
+  };
+}
+
+export function buildOnboardedConfig(
+  applyBuiltinDefaults: boolean,
+): GuardrailsConfig {
+  return {
+    version: CURRENT_VERSION,
+    applyBuiltinDefaults,
+    onboarding: {
+      completed: true,
+      completedAt: new Date().toISOString(),
+      version: CURRENT_VERSION,
+    },
+  };
+}
+
+export function isOnboardingPending(config: GuardrailsConfig | null): boolean {
+  if (!config) return true;
+  return config.onboarding?.completed !== true;
+}

--- a/src/commands/settings-command.ts
+++ b/src/commands/settings-command.ts
@@ -258,6 +258,118 @@ const COMMAND_EXAMPLES: Array<{
     description: "Require confirmation for table drops",
     pattern: { pattern: "DROP TABLE", description: "SQL table drop" },
   },
+  {
+    label: "dbt run",
+    description: "Require confirmation for dbt model runs",
+    pattern: {
+      pattern: "dbt run",
+      description: "dbt model execution",
+    },
+  },
+  {
+    label: "dbt seed",
+    description: "Require confirmation for dbt seed data loading",
+    pattern: {
+      pattern: "dbt seed",
+      description: "dbt seed data loading",
+    },
+  },
+  {
+    label: "aws s3 rm",
+    description: "Require confirmation for AWS S3 deletions",
+    pattern: {
+      pattern: "aws s3 rm",
+      description: "AWS S3 object deletion",
+    },
+  },
+  {
+    label: "aws iam",
+    description: "Require confirmation for AWS IAM changes",
+    pattern: {
+      pattern: "aws iam",
+      description: "AWS IAM permission changes",
+    },
+  },
+  {
+    label: "aws ec2 terminate",
+    description: "Require confirmation for EC2 instance termination",
+    pattern: {
+      pattern: "aws ec2 terminate-instances",
+      description: "AWS EC2 instance termination",
+    },
+  },
+  {
+    label: "kubectl apply",
+    description: "Require confirmation for k8s resource application",
+    pattern: {
+      pattern: "kubectl apply",
+      description: "Kubernetes resource application",
+    },
+  },
+  {
+    label: "kubectl scale",
+    description: "Require confirmation for k8s scaling operations",
+    pattern: {
+      pattern: "kubectl scale",
+      description: "Kubernetes scaling operation",
+    },
+  },
+  {
+    label: "docker rm",
+    description: "Require confirmation for Docker container removal",
+    pattern: {
+      pattern: "docker rm",
+      description: "Docker container removal",
+    },
+  },
+  {
+    label: "docker rmi",
+    description: "Require confirmation for Docker image removal",
+    pattern: {
+      pattern: "docker rmi",
+      description: "Docker image removal",
+    },
+  },
+  {
+    label: "docker compose down",
+    description: "Require confirmation for Docker Compose teardown",
+    pattern: {
+      pattern: "docker compose down",
+      description: "Docker Compose service teardown",
+    },
+  },
+  {
+    label: "terraform import",
+    description: "Require confirmation for Terraform resource import",
+    pattern: {
+      pattern: "terraform import",
+      description: "Terraform resource import",
+    },
+  },
+  {
+    label: "gcloud compute delete",
+    description: "Require confirmation for GCP compute instance deletion",
+    pattern: {
+      pattern: "gcloud compute instances delete",
+      description: "GCP compute instance deletion",
+    },
+  },
+  {
+    label: "gcloud iam",
+    description: "Require confirmation for GCP IAM changes",
+    pattern: {
+      pattern: "gcloud iam",
+      description: "GCP IAM permission changes",
+    },
+  },
+  {
+    label: "gcloud sql delete",
+    description: "Require confirmation for GCP SQL instance deletion",
+    pattern: {
+      pattern: "gcloud sql instances delete",
+      description: "GCP Cloud SQL instance deletion",
+    },
+  },
 ];
 
 function toKebabCase(input: string): string {

--- a/src/commands/settings-command.ts
+++ b/src/commands/settings-command.ts
@@ -957,7 +957,7 @@ export function registerGuardrailsSettings(pi: ExtensionAPI): void {
     buildSections: (
       tabConfig: GuardrailsConfig | null,
       _resolved: ResolvedConfig,
-      { setDraft, theme },
+      { setDraft, theme, scope },
     ): SettingsSection[] => {
       const settingsTheme = theme;
       let scopedConfig = structuredClone(tabConfig ?? {}) as GuardrailsConfig;
@@ -1117,9 +1117,11 @@ export function registerGuardrailsSettings(pi: ExtensionAPI): void {
         return scopedConfig.permissionGate?.explainTimeout ?? null;
       }
 
-      const featureItems = (Object.keys(FEATURE_UI) as FeatureKey[])
+      const featureItems: SettingItem[] = (
+        Object.keys(FEATURE_UI) as FeatureKey[]
+      )
         .filter((key) => key !== "policies")
-        .map((key) => {
+        .map((key): SettingItem => {
           const scopedValue = scopedConfig.features?.[key];
           return {
             id: `features.${key}`,
@@ -1134,6 +1136,18 @@ export function registerGuardrailsSettings(pi: ExtensionAPI): void {
             values: ["enabled", "disabled"],
           };
         });
+
+      if (scope === "global") {
+        featureItems.push({
+          id: "onboarding.run",
+          label: "Onboarding status",
+          description: "Use /guardrails:onboarding to run onboarding",
+          currentValue:
+            scopedConfig.onboarding?.completed === true
+              ? "completed"
+              : "pending",
+        });
+      }
 
       const policyRules = getPolicyRules();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,8 @@ export interface PolicyRule {
 export interface GuardrailsConfig {
   version?: string;
   enabled?: boolean;
+  /** Deprecated-defaults bridge: when true, applies built-in policy defaults. */
+  applyBuiltinDefaults?: boolean;
   features?: {
     policies?: boolean;
     permissionGate?: boolean;
@@ -90,6 +92,7 @@ export interface GuardrailsConfig {
 export interface ResolvedConfig {
   version: string;
   enabled: boolean;
+  applyBuiltinDefaults: boolean;
   features: {
     policies: boolean;
     permissionGate: boolean;
@@ -115,8 +118,10 @@ import { ConfigLoader, type Migration } from "@aliou/pi-utils-settings";
 import {
   backupConfig,
   CURRENT_VERSION,
+  migrateApplyBuiltinDefaults,
   migrateEnvFilesToPolicies,
   migrateV0,
+  needsApplyBuiltinDefaultsMigration,
   needsEnvFilesToPoliciesMigration,
   needsMigration,
 } from "./utils/migration";
@@ -182,11 +187,17 @@ const migrations: Migration<GuardrailsConfig>[] = [
     shouldRun: (config) => needsEnvFilesToPoliciesMigration(config),
     run: (config) => migrateEnvFilesToPolicies(config),
   },
+  {
+    name: "apply-builtin-defaults-bridge",
+    shouldRun: (config) => needsApplyBuiltinDefaultsMigration(config),
+    run: (config) => migrateApplyBuiltinDefaults(config),
+  },
 ];
 
 const DEFAULT_CONFIG: ResolvedConfig = {
   version: CURRENT_VERSION,
   enabled: true,
+  applyBuiltinDefaults: true,
   features: {
     policies: true,
     permissionGate: true,
@@ -295,8 +306,10 @@ export const configLoader = new ConfigLoader<GuardrailsConfig, ResolvedConfig>(
     afterMerge: (resolved, global, local, memory) => {
       const ruleMap = new Map<string, PolicyRule>();
 
-      for (const rule of DEFAULT_CONFIG.policies.rules) {
-        ruleMap.set(rule.id, rule);
+      if (resolved.applyBuiltinDefaults) {
+        for (const rule of DEFAULT_CONFIG.policies.rules) {
+          ruleMap.set(rule.id, rule);
+        }
       }
       if (global?.policies?.rules) {
         for (const rule of global.policies.rules) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -217,6 +217,51 @@ const DEFAULT_CONFIG: ResolvedConfig = {
           "Accessing {file} is not allowed. This file contains secrets. " +
           "Explain to the user why you want to access this file, and if changes are needed ask the user to make them.",
       },
+      {
+        id: "home-ssh",
+        description: "SSH directory and keys",
+        enabled: false,
+        patterns: [
+          { pattern: "~/.ssh/**" },
+          { pattern: "~/.ssh/*_rsa" },
+          { pattern: "~/.ssh/*_ed25519" },
+          { pattern: "~/.ssh/*.pem" },
+        ],
+        allowedPatterns: [{ pattern: "~/.ssh/*.pub" }],
+        protection: "noAccess",
+        onlyIfExists: true,
+        blockMessage:
+          "Accessing {file} is not allowed. This file is part of your SSH configuration and may contain private keys or sensitive host information.",
+      },
+      {
+        id: "home-config",
+        description: "Sensitive user configuration directories",
+        enabled: false,
+        patterns: [
+          { pattern: "~/.config/gh/**" },
+          { pattern: "~/.config/gcloud/**" },
+          { pattern: "~/.config/op/**" },
+          { pattern: "~/.config/sops/**" },
+        ],
+        protection: "noAccess",
+        onlyIfExists: true,
+        blockMessage:
+          "Accessing {file} is not allowed. This file is in a sensitive user configuration directory and may contain credentials or tokens.",
+      },
+      {
+        id: "home-gpg",
+        description: "GPG keys and configuration",
+        enabled: false,
+        patterns: [
+          { pattern: "~/.gnupg/**" },
+          { pattern: "~/*.gpg" },
+          { pattern: "~/.gpg-agent.conf" },
+        ],
+        protection: "noAccess",
+        onlyIfExists: true,
+        blockMessage:
+          "Accessing {file} is not allowed. This file is part of your GPG configuration and may contain private keys or trust settings.",
+      },
     ],
   },
   permissionGate: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,11 @@ export interface GuardrailsConfig {
   enabled?: boolean;
   /** Deprecated-defaults bridge: when true, applies built-in policy defaults. */
   applyBuiltinDefaults?: boolean;
+  onboarding?: {
+    completed?: boolean;
+    completedAt?: string;
+    version?: string;
+  };
   features?: {
     policies?: boolean;
     permissionGate?: boolean;
@@ -118,10 +123,8 @@ import { ConfigLoader, type Migration } from "@aliou/pi-utils-settings";
 import {
   backupConfig,
   CURRENT_VERSION,
-  migrateApplyBuiltinDefaults,
   migrateEnvFilesToPolicies,
   migrateV0,
-  needsApplyBuiltinDefaultsMigration,
   needsEnvFilesToPoliciesMigration,
   needsMigration,
 } from "./utils/migration";
@@ -186,11 +189,6 @@ const migrations: Migration<GuardrailsConfig>[] = [
     name: "envFiles-to-policies",
     shouldRun: (config) => needsEnvFilesToPoliciesMigration(config),
     run: (config) => migrateEnvFilesToPolicies(config),
-  },
-  {
-    name: "apply-builtin-defaults-bridge",
-    shouldRun: (config) => needsApplyBuiltinDefaultsMigration(config),
-    run: (config) => migrateApplyBuiltinDefaults(config),
   },
 ];
 

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -10,6 +10,7 @@ import {
   compileFilePatterns,
   normalizeFilePath,
 } from "../utils/matching";
+import { expandHomePath } from "../utils/path";
 import { walkCommands, wordToString } from "../utils/shell-utils";
 import { pendingWarnings } from "../utils/warnings";
 
@@ -37,9 +38,9 @@ interface CompiledRule {
   enabled: boolean;
 }
 
-async function fileExists(cwd: string, filePath: string): Promise<boolean> {
+async function fileExists(filePath: string, cwd: string): Promise<boolean> {
   try {
-    await stat(resolve(cwd, filePath));
+    await stat(resolvePolicyPath(filePath, cwd));
     return true;
   } catch {
     return false;
@@ -118,13 +119,28 @@ function maybePathLike(token: string): boolean {
 }
 
 function normalizeTargetForPolicy(filePath: string, cwd: string): string {
-  const absolute = resolve(cwd, filePath);
+  if (filePath === "~" || filePath.startsWith("~/")) {
+    return normalizeFilePath(filePath);
+  }
+
+  const expanded = expandHomePath(filePath);
+  const absolute = resolve(cwd, expanded);
   const rel = relative(cwd, absolute);
+  const normalizedHome = normalizeFilePath(expandHomePath("~"));
+  const normalizedAbsolute = normalizeFilePath(absolute);
+
+  if (normalizedAbsolute.startsWith(`${normalizedHome}/`)) {
+    return normalizeFilePath(`~/${relative(expandHomePath("~"), absolute)}`);
+  }
 
   const candidate =
     rel && !rel.startsWith("..") && !isAbsolute(rel) ? rel : absolute;
 
   return normalizeFilePath(candidate);
+}
+
+function resolvePolicyPath(filePath: string, cwd: string): string {
+  return resolve(cwd, expandHomePath(filePath));
 }
 
 function matchesAnyPolicyPattern(
@@ -236,7 +252,7 @@ async function getEffectiveProtection(
     );
     if (allowed) continue;
 
-    if (rule.onlyIfExists && !(await fileExists(cwd, filePath))) continue;
+    if (rule.onlyIfExists && !(await fileExists(filePath, cwd))) continue;
 
     const rank = protectionRank(rule.protection);
     if (!bestMatch || rank > bestMatch.rank) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { isOnboardingPending } from "./commands/onboarding";
+import { registerGuardrailsOnboardingCommand } from "./commands/onboarding-command";
 import { registerGuardrailsSettings } from "./commands/settings-command";
-import { configLoader, type GuardrailsConfig } from "./config";
+import { configLoader } from "./config";
 import { setupGuardrailsHooks } from "./hooks";
-import { CURRENT_VERSION } from "./utils/migration";
+import {
+  migrateApplyBuiltinDefaults,
+  migrateMarkOnboardingDone,
+  needsApplyBuiltinDefaultsMigration,
+  needsOnboardingDoneMigration,
+} from "./utils/migration";
 import { pendingWarnings } from "./utils/warnings";
 
 /**
@@ -24,26 +31,66 @@ import { pendingWarnings } from "./utils/warnings";
 export default async function (pi: ExtensionAPI) {
   await configLoader.load();
 
-  // First-run bootstrap: create global settings file with explicit
-  // applyBuiltinDefaults=false (no warning, no migration path).
-  if (!configLoader.hasConfig("global")) {
-    const bootstrap: GuardrailsConfig = {
-      version: CURRENT_VERSION,
-      applyBuiltinDefaults: false,
-    };
-    await configLoader.save("global", bootstrap);
+  const hasGlobalConfig = configLoader.hasConfig("global");
+
+  if (hasGlobalConfig) {
+    const globalConfig = configLoader.getRawConfig("global");
+    if (globalConfig) {
+      let migrated = globalConfig;
+      let changed = false;
+
+      if (needsApplyBuiltinDefaultsMigration(migrated)) {
+        migrated = migrateApplyBuiltinDefaults(migrated);
+        changed = true;
+      }
+
+      if (needsOnboardingDoneMigration(migrated)) {
+        migrated = migrateMarkOnboardingDone(migrated);
+        changed = true;
+      }
+
+      if (changed) {
+        await configLoader.save("global", migrated);
+        await configLoader.load();
+      }
+    }
   }
 
-  const config = configLoader.getConfig();
+  let hooksRegistered = false;
 
-  if (!config.enabled) return;
-
-  setupGuardrailsHooks(pi, config);
   registerGuardrailsSettings(pi);
+
+  const maybeRegisterHooks = () => {
+    if (hooksRegistered) return;
+    const config = configLoader.getConfig();
+    if (!config.enabled) return;
+    setupGuardrailsHooks(pi, config);
+    hooksRegistered = true;
+  };
+
+  if (isOnboardingPending(configLoader.getRawConfig("global"))) {
+    registerGuardrailsOnboardingCommand(pi, maybeRegisterHooks);
+  } else {
+    maybeRegisterHooks();
+  }
 
   pi.on("session_start", (_event, ctx) => {
     for (const warning of pendingWarnings.splice(0)) {
       ctx.ui.notify(warning, "warning");
     }
+
+    if (!ctx.hasUI) {
+      return;
+    }
+
+    if (isOnboardingPending(configLoader.getRawConfig("global"))) {
+      ctx.ui.notify(
+        "[Guardrails] setup pending. Run `/guardrails:onboarding` to choose recommended or minimal protection defaults.",
+        "info",
+      );
+      return;
+    }
+
+    maybeRegisterHooks();
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerGuardrailsSettings } from "./commands/settings-command";
-import { configLoader } from "./config";
+import { configLoader, type GuardrailsConfig } from "./config";
 import { setupGuardrailsHooks } from "./hooks";
+import { CURRENT_VERSION } from "./utils/migration";
 import { pendingWarnings } from "./utils/warnings";
 
 /**
@@ -22,6 +23,17 @@ import { pendingWarnings } from "./utils/warnings";
  */
 export default async function (pi: ExtensionAPI) {
   await configLoader.load();
+
+  // First-run bootstrap: create global settings file with explicit
+  // applyBuiltinDefaults=false (no warning, no migration path).
+  if (!configLoader.hasConfig("global")) {
+    const bootstrap: GuardrailsConfig = {
+      version: CURRENT_VERSION,
+      applyBuiltinDefaults: false,
+    };
+    await configLoader.save("global", bootstrap);
+  }
+
   const config = configLoader.getConfig();
 
   if (!config.enabled) return;

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -21,7 +21,7 @@ import { pendingWarnings } from "./warnings";
  * Keep this independent from package.json version.
  * Bump only when config schema/default migration markers change.
  */
-export const CURRENT_VERSION = "0.8.0-20260228";
+export const CURRENT_VERSION = "0.9.0-20260323";
 
 /**
  * Check if a config needs migration (no version field = v0).
@@ -95,6 +95,36 @@ export function needsEnvFilesToPoliciesMigration(
 
   const features = raw.features as Record<string, unknown> | undefined;
   return features?.protectEnvFiles !== undefined;
+}
+
+/**
+ * Check if config needs applyBuiltinDefaults bridge migration.
+ * This runs only for existing config files loaded by ConfigLoader.
+ */
+export function needsApplyBuiltinDefaultsMigration(
+  config: GuardrailsConfig,
+): boolean {
+  return config.applyBuiltinDefaults === undefined;
+}
+
+/**
+ * Bridge migration for defaults deprecation.
+ * Existing config files get applyBuiltinDefaults=true to preserve behavior.
+ */
+export function migrateApplyBuiltinDefaults(
+  config: GuardrailsConfig,
+): GuardrailsConfig {
+  const migrated = structuredClone(config);
+  migrated.applyBuiltinDefaults = true;
+  migrated.version = CURRENT_VERSION;
+
+  pendingWarnings.push(
+    "Guardrails config was migrated. `applyBuiltinDefaults` was set to `true` to preserve current behavior.\n" +
+      "Built-in policy defaults will be deprecated in a future version. " +
+      "Use /guardrails:settings -> Policies -> Apply defaults to store the current defaults in your global settings file (`~/.pi/agent/extensions/guardrails.json`).",
+  );
+
+  return migrated;
 }
 
 /**

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -21,7 +21,7 @@ import { pendingWarnings } from "./warnings";
  * Keep this independent from package.json version.
  * Bump only when config schema/default migration markers change.
  */
-export const CURRENT_VERSION = "0.9.0-20260323";
+export const CURRENT_VERSION = "0.9.0-20260327";
 
 /**
  * Check if a config needs migration (no version field = v0).
@@ -119,11 +119,35 @@ export function migrateApplyBuiltinDefaults(
   migrated.version = CURRENT_VERSION;
 
   pendingWarnings.push(
-    "Guardrails config was migrated. `applyBuiltinDefaults` was set to `true` to preserve current behavior.\n" +
-      "Built-in policy defaults will be deprecated in a future version. " +
-      "Use /guardrails:settings -> Policies -> Apply defaults to store the current defaults in your global settings file (`~/.pi/agent/extensions/guardrails.json`).",
+    "Guardrails config was migrated. `applyBuiltinDefaults` was set to `true` to preserve current behavior.",
   );
 
+  return migrated;
+}
+
+export function needsOnboardingDoneMigration(
+  config: GuardrailsConfig,
+): boolean {
+  return (
+    config.onboarding?.completed === undefined &&
+    config.applyBuiltinDefaults !== undefined
+  );
+}
+
+export function migrateMarkOnboardingDone(
+  config: GuardrailsConfig,
+): GuardrailsConfig {
+  const migrated = structuredClone(config);
+  pendingWarnings.push(
+    "Guardrails config was migrated. Existing setup marked as onboarding-complete.",
+  );
+  migrated.onboarding = {
+    ...(migrated.onboarding ?? {}),
+    completed: true,
+    completedAt: migrated.onboarding?.completedAt ?? new Date().toISOString(),
+    version: migrated.onboarding?.version ?? CURRENT_VERSION,
+  };
+  migrated.version = CURRENT_VERSION;
   return migrated;
 }
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,18 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Expand a leading tilde to the current user's home directory.
+ * Preserves all other paths unchanged.
+ */
+export function expandHomePath(input: string): string {
+  if (input === "~") {
+    return homedir();
+  }
+
+  if (input.startsWith("~/")) {
+    return join(homedir(), input.slice(2));
+  }
+
+  return input;
+}


### PR DESCRIPTION
## Summary

- add home-directory default policy rules (`home-ssh`, `home-config`, `home-gpg`) as disabled-by-default presets
- fix `~` expansion and path normalization for policy matching
- expand settings examples and docs (`docs/defaults.md`, `docs/examples.md`)
- add command-based onboarding for new users:
  - new `/guardrails:onboarding`
  - session-start hint when onboarding is pending
  - onboarding state persisted in global config
  - no forced auto-open onboarding

## Onboarding behavior

- existing users are backfilled and treated as already onboarded
- new/pending users see:
  - `[Guardrails] setup pending. Run /guardrails:onboarding ...`
- onboarding runs as overlay UI (not nested settings wizard)
- users choose between:
  - `Recommended defaults`
  - `Minimal setup`

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` — clean
