### PR TITLE
Feature/nikitakot add path filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Each rule has:
 
 - `id`: stable identifier used for overrides across scopes.
 - `patterns`: files to match (glob by default, regex if `regex: true`). Glob semantics: patterns containing `/` match the full relative path; patterns without `/` match basename only.
-- `allowedPatterns`: exceptions.
+  - `relativeOnly`: when `true`, pattern only matches files inside the current working directory.
+- `allowedPatterns`: exceptions (same format as `patterns`).
 - `protection`:
   - `noAccess`: block `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`
   - `readOnly`: block `write`, `edit`, `bash`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,15 @@ Each rule has:
 
 - `id`: stable identifier used for overrides across scopes.
 - `patterns`: files to match (glob by default, regex if `regex: true`). Glob semantics: patterns containing `/` match the full relative path; patterns without `/` match basename only.
-  - `relativeOnly`: when `true`, pattern only matches files inside the current working directory.
+  - `pathFilter`: optional array of paths to restrict matches to. Supports:
+    - `.` or `./something` - relative to current working directory
+    - `../something` - parent of cwd
+    - `~/something` or `~` - home directory
+    - Absolute paths like `/home/user/docs` or `C:/Windows/System32`
+    Pattern matches if file is inside ANY of the specified paths.
+    If not set, pattern matches anywhere (no restriction).
+
+    Example: `"pathFilter": ["."]` for cwd only, `"pathFilter": [".", "~/.config"]` for cwd and home config.
 - `allowedPatterns`: exceptions (same format as `patterns`).
 - `protection`:
   - `noAccess`: block `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export interface FilePatternConfig extends PatternConfig {
 }
 
 /**
- * Command pattern config (no basePath, not applicable in command context).
+ * Command pattern config (no pathFilter, not applicable in command context).
  */
 export type CommandPatternConfig = PatternConfig;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,9 +6,9 @@
  */
 
 /**
- * A pattern with explicit matching mode.
- * Default: glob for files, substring for commands.
- * regex: true means full regex matching.
+ * Base pattern with explicit matching mode.
+ * - Default: glob for files, substring for commands.
+ * - regex: true means full regex matching.
  */
 export interface PatternConfig {
   pattern: string;
@@ -16,11 +16,25 @@ export interface PatternConfig {
 }
 
 /**
+ * File pattern config with relativeOnly support.
+ * - relativeOnly: true means only match if the resolved path is inside the
+ *   current working directory.
+ */
+export interface FilePatternConfig extends PatternConfig {
+  relativeOnly?: boolean;
+}
+
+/**
+ * Command pattern config (no relativeOnly, not applicable in command context).
+ */
+export type CommandPatternConfig = PatternConfig;
+
+/**
  * Permission gate pattern. When regex is false (default), the pattern
  * is matched as substring against the raw command string.
  * When regex is true, uses full regex against the raw string.
  */
-export interface DangerousPattern extends PatternConfig {
+export interface DangerousPattern extends CommandPatternConfig {
   description: string;
 }
 
@@ -40,9 +54,9 @@ export interface PolicyRule {
   /** Human-readable description. */
   description?: string;
   /** File patterns to protect. */
-  patterns: PatternConfig[];
+  patterns: FilePatternConfig[];
   /** Optional exceptions. */
-  allowedPatterns?: PatternConfig[];
+  allowedPatterns?: FilePatternConfig[];
   /** Protection level. */
   protection: Protection;
   /** Block only when file exists on disk. Default true. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,16 +16,21 @@ export interface PatternConfig {
 }
 
 /**
- * File pattern config with relativeOnly support.
- * - relativeOnly: true means only match if the resolved path is inside the
- *   current working directory.
+ * File pattern config with pathFilter support.
+ * - pathFilter: optional array of paths to restrict matches to. Supports:
+ *   - "." or "./" for current working directory
+ *   - "../" for parent of cwd
+ *   - "~" or "~/" for home directory
+ *   - Absolute paths (e.g., "/home/user/docs", "C:/Windows")
+ *   Pattern matches if file is inside ANY of the specified paths.
+ *   If not set, pattern matches anywhere (no restriction).
  */
 export interface FilePatternConfig extends PatternConfig {
-  relativeOnly?: boolean;
+  pathFilter?: string[];
 }
 
 /**
- * Command pattern config (no relativeOnly, not applicable in command context).
+ * Command pattern config (no basePath, not applicable in command context).
  */
 export type CommandPatternConfig = PatternConfig;
 

--- a/src/hooks/permission-gate.ts
+++ b/src/hooks/permission-gate.ts
@@ -21,7 +21,7 @@ import { configLoader } from "../config";
 import { executeSubagent, resolveModel } from "../lib";
 import { emitBlocked, emitDangerous } from "../utils/events";
 import {
-  type CompiledPattern,
+  type CompiledCommandPattern,
   compileCommandPatterns,
 } from "../utils/matching";
 import { walkCommands, wordToString } from "../utils/shell-utils";
@@ -182,7 +182,7 @@ function checkBuiltinDangerous(words: string[]): DangerMatch | undefined {
  */
 function findDangerousMatch(
   command: string,
-  compiledPatterns: CompiledPattern[],
+  compiledPatterns: CompiledCommandPattern[],
   useBuiltinMatchers: boolean,
   fallbackPatterns: DangerousPattern[],
 ): DangerMatch | undefined {

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -6,7 +6,7 @@ import type { PolicyRule, Protection, ResolvedConfig } from "../config";
 import { emitBlocked } from "../utils/events";
 import { expandGlob, hasGlobChars } from "../utils/glob-expander";
 import {
-  type CompiledPattern,
+  type CompiledFilePattern,
   compileFilePatterns,
   normalizeFilePath,
 } from "../utils/matching";
@@ -31,8 +31,8 @@ const BLOCKED_TOOLS: Record<Protection, Set<string>> = {
 interface CompiledRule {
   id: string;
   protection: Protection;
-  patterns: CompiledPattern[];
-  allowedPatterns: CompiledPattern[];
+  patterns: CompiledFilePattern[];
+  allowedPatterns: CompiledFilePattern[];
   onlyIfExists: boolean;
   blockMessage: string;
   enabled: boolean;
@@ -146,10 +146,12 @@ function resolvePolicyPath(filePath: string, cwd: string): string {
 function matchesAnyPolicyPattern(
   filePath: string,
   rules: CompiledRule[],
+  cwd: string,
 ): boolean {
   return rules.some(
     (rule) =>
-      rule.enabled && rule.patterns.some((pattern) => pattern.test(filePath)),
+      rule.enabled &&
+      rule.patterns.some((pattern) => pattern.test(filePath, cwd)),
   );
 }
 
@@ -175,7 +177,7 @@ async function extractBashFileTargets(
     const expanded = await expandCandidate(candidate);
     for (const file of expanded) {
       const normalized = normalizeTargetForPolicy(file, cwd);
-      if (matchesAnyPolicyPattern(normalized, rules)) {
+      if (matchesAnyPolicyPattern(normalized, rules, cwd)) {
         targets.add(normalized);
       }
     }
@@ -215,7 +217,7 @@ async function extractBashFileTargets(
       const expanded = await expandCandidate(token);
       for (const file of expanded) {
         const normalized = normalizeTargetForPolicy(file, cwd);
-        if (matchesAnyPolicyPattern(normalized, rules)) {
+        if (matchesAnyPolicyPattern(normalized, rules, cwd)) {
           targets.add(normalized);
         }
       }
@@ -244,11 +246,13 @@ async function getEffectiveProtection(
   for (const rule of compiledRules) {
     if (!rule.enabled) continue;
 
-    const matched = rule.patterns.some((pattern) => pattern.test(filePath));
+    const matched = rule.patterns.some((pattern) =>
+      pattern.test(filePath, cwd),
+    );
     if (!matched) continue;
 
     const allowed = rule.allowedPatterns.some((pattern) =>
-      pattern.test(filePath),
+      pattern.test(filePath, cwd),
     );
     if (allowed) continue;
 

--- a/src/utils/matching.ts
+++ b/src/utils/matching.ts
@@ -9,12 +9,22 @@
  */
 
 import { matchesGlob } from "node:path";
-import type { PatternConfig } from "../config";
+import type { CommandPatternConfig, FilePatternConfig } from "../config";
+import { isPathInside } from "./path";
 import { pendingWarnings } from "./warnings";
 
-export interface CompiledPattern {
+interface CompiledPatternBase<TConfig> {
+  source: TConfig;
+}
+
+export interface CompiledFilePattern
+  extends CompiledPatternBase<FilePatternConfig> {
+  test: (input: string, cwd: string) => boolean;
+}
+
+export interface CompiledCommandPattern
+  extends CompiledPatternBase<CommandPatternConfig> {
   test: (input: string) => boolean;
-  source: PatternConfig;
 }
 
 /**
@@ -38,12 +48,21 @@ export function normalizeFilePath(input: string): string {
  * - Otherwise, match basename only (backward compatible).
  * regex: true -> full regex (case-insensitive) against normalized path.
  */
-export function compileFilePattern(config: PatternConfig): CompiledPattern {
+export function compileFilePattern(
+  config: FilePatternConfig,
+): CompiledFilePattern {
   if (config.regex) {
     try {
       const re = new RegExp(config.pattern, "i");
       return {
-        test: (input) => re.test(normalizeFilePath(input)),
+        test: (input: string, cwd: string) => {
+          const normalized = normalizeFilePath(input);
+          if (!re.test(normalized)) return false;
+          if (config.relativeOnly) {
+            return isPathInside(cwd, input);
+          }
+          return true;
+        },
         source: config,
       };
     } catch {
@@ -57,13 +76,18 @@ export function compileFilePattern(config: PatternConfig): CompiledPattern {
   const matchFullPath = config.pattern.includes("/");
 
   return {
-    test: (input) => {
+    test: (input: string, cwd: string) => {
       const normalized = normalizeFilePath(input);
       const candidate = matchFullPath
         ? normalized
         : (normalized.split("/").pop() ?? normalized);
 
-      return matchesGlob(candidate, config.pattern);
+      const matches = matchesGlob(candidate, config.pattern);
+      if (!matches) return false;
+      if (config.relativeOnly) {
+        return isPathInside(cwd, input);
+      }
+      return true;
     },
     source: config,
   };
@@ -74,11 +98,13 @@ export function compileFilePattern(config: PatternConfig): CompiledPattern {
  * Default: substring match against raw command string.
  * regex: true -> full regex against raw command string.
  */
-export function compileCommandPattern(config: PatternConfig): CompiledPattern {
+export function compileCommandPattern(
+  config: CommandPatternConfig,
+): CompiledCommandPattern {
   if (config.regex) {
     try {
       const re = new RegExp(config.pattern);
-      return { test: (input) => re.test(input), source: config };
+      return { test: (input: string) => re.test(input), source: config };
     } catch {
       pendingWarnings.push(
         `Invalid regex in guardrails config: ${config.pattern}`,
@@ -88,7 +114,7 @@ export function compileCommandPattern(config: PatternConfig): CompiledPattern {
   }
 
   return {
-    test: (input) => input.includes(config.pattern),
+    test: (input: string) => input.includes(config.pattern),
     source: config,
   };
 }
@@ -97,8 +123,8 @@ export function compileCommandPattern(config: PatternConfig): CompiledPattern {
  * Compile an array of patterns for file-context matching.
  */
 export function compileFilePatterns(
-  configs: PatternConfig[],
-): CompiledPattern[] {
+  configs: FilePatternConfig[],
+): CompiledFilePattern[] {
   return configs.map(compileFilePattern);
 }
 
@@ -106,7 +132,7 @@ export function compileFilePatterns(
  * Compile an array of patterns for command-context matching.
  */
 export function compileCommandPatterns(
-  configs: PatternConfig[],
-): CompiledPattern[] {
+  configs: CommandPatternConfig[],
+): CompiledCommandPattern[] {
   return configs.map(compileCommandPattern);
 }

--- a/src/utils/matching.ts
+++ b/src/utils/matching.ts
@@ -55,7 +55,7 @@ export function compileFilePattern(
     try {
       const re = new RegExp(config.pattern, "i");
       return {
-        test: (input: string, cwd: string) => {
+        test: (input, cwd) => {
           const normalized = normalizeFilePath(input);
           if (!re.test(normalized)) return false;
           if (config.relativeOnly) {
@@ -76,7 +76,7 @@ export function compileFilePattern(
   const matchFullPath = config.pattern.includes("/");
 
   return {
-    test: (input: string, cwd: string) => {
+    test: (input, cwd) => {
       const normalized = normalizeFilePath(input);
       const candidate = matchFullPath
         ? normalized
@@ -104,7 +104,7 @@ export function compileCommandPattern(
   if (config.regex) {
     try {
       const re = new RegExp(config.pattern);
-      return { test: (input: string) => re.test(input), source: config };
+      return { test: (input) => re.test(input), source: config };
     } catch {
       pendingWarnings.push(
         `Invalid regex in guardrails config: ${config.pattern}`,
@@ -114,7 +114,7 @@ export function compileCommandPattern(
   }
 
   return {
-    test: (input: string) => input.includes(config.pattern),
+    test: (input) => input.includes(config.pattern),
     source: config,
   };
 }

--- a/src/utils/matching.ts
+++ b/src/utils/matching.ts
@@ -10,7 +10,7 @@
 
 import { matchesGlob } from "node:path";
 import type { CommandPatternConfig, FilePatternConfig } from "../config";
-import { isPathInside } from "./path";
+import { isPathInsideAny } from "./path";
 import { pendingWarnings } from "./warnings";
 
 interface CompiledPatternBase<TConfig> {
@@ -58,8 +58,8 @@ export function compileFilePattern(
         test: (input, cwd) => {
           const normalized = normalizeFilePath(input);
           if (!re.test(normalized)) return false;
-          if (config.relativeOnly) {
-            return isPathInside(cwd, input);
+          if (config.pathFilter !== undefined) {
+            return isPathInsideAny(config.pathFilter, cwd, input);
           }
           return true;
         },
@@ -84,8 +84,8 @@ export function compileFilePattern(
 
       const matches = matchesGlob(candidate, config.pattern);
       if (!matches) return false;
-      if (config.relativeOnly) {
-        return isPathInside(cwd, input);
+      if (config.pathFilter !== undefined) {
+        return isPathInsideAny(config.pathFilter, cwd, input);
       }
       return true;
     },

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -18,6 +18,29 @@ export function expandHomePath(input: string): string {
 }
 
 /**
+ * Resolve a basePath value to an absolute path.
+ * Supports:
+ *   - "." or "./" for current working directory
+ *   - "../" for parent directories relative to cwd
+ *   - "~" or "~/" for home directory
+ *   - Absolute paths (returned as-is)
+ *
+ * Returns null if the path cannot be resolved.
+ */
+export function resolveBasePath(basePath: string, cwd: string): string | null {
+  // Expand home directory first
+  const expanded = expandHomePath(basePath);
+
+  // If it's already absolute after home expansion, return it
+  if (isAbsolute(expanded)) {
+    return resolve(expanded);
+  }
+
+  // Otherwise, resolve relative to cwd
+  return resolve(cwd, expanded);
+}
+
+/**
  * Check if a child path is inside a parent directory.
  */
 export function isPathInside(parentDir: string, childPath: string): boolean {
@@ -26,4 +49,23 @@ export function isPathInside(parentDir: string, childPath: string): boolean {
   const rel = relative(resolvedParent, resolvedChild);
 
   return !rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel);
+}
+
+/**
+ * Check if a child path is inside any of the parent directories.
+ * Returns true if the path is inside at least one parent directory.
+ */
+export function isPathInsideAny(
+  basePaths: string[],
+  cwd: string,
+  childPath: string,
+): boolean {
+  for (const basePath of basePaths) {
+    const resolvedBase = resolveBasePath(basePath, cwd);
+    if (resolvedBase && isPathInside(resolvedBase, childPath)) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -18,7 +18,7 @@ export function expandHomePath(input: string): string {
 }
 
 /**
- * Resolve a basePath value to an absolute path.
+ * Resolve a pathFilter value to an absolute path.
  * Supports:
  *   - "." or "./" for current working directory
  *   - "../" for parent directories relative to cwd
@@ -27,9 +27,12 @@ export function expandHomePath(input: string): string {
  *
  * Returns null if the path cannot be resolved.
  */
-export function resolveBasePath(basePath: string, cwd: string): string | null {
+export function resolvePathFilter(
+  pathFilter: string,
+  cwd: string,
+): string | null {
   // Expand home directory first
-  const expanded = expandHomePath(basePath);
+  const expanded = expandHomePath(pathFilter);
 
   // If it's already absolute after home expansion, return it
   if (isAbsolute(expanded)) {
@@ -56,13 +59,13 @@ export function isPathInside(parentDir: string, childPath: string): boolean {
  * Returns true if the path is inside at least one parent directory.
  */
 export function isPathInsideAny(
-  basePaths: string[],
+  pathFilters: string[],
   cwd: string,
   childPath: string,
 ): boolean {
-  for (const basePath of basePaths) {
-    const resolvedBase = resolveBasePath(basePath, cwd);
-    if (resolvedBase && isPathInside(resolvedBase, childPath)) {
+  for (const pathFilter of pathFilters) {
+    const resolvedFilter = resolvePathFilter(pathFilter, cwd);
+    if (resolvedFilter && isPathInside(resolvedFilter, childPath)) {
       return true;
     }
   }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -10,7 +10,7 @@ export function expandHomePath(input: string): string {
     return homedir();
   }
 
-  if (input.startsWith("~/")) {
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
     return join(homedir(), input.slice(2));
   }
 
@@ -21,8 +21,8 @@ export function expandHomePath(input: string): string {
  * Check if a child path is inside a parent directory.
  */
 export function isPathInside(parentDir: string, childPath: string): boolean {
-  const resolvedParent = resolve(parentDir);
-  const resolvedChild = resolve(childPath);
+  const resolvedParent = resolve(expandHomePath(parentDir));
+  const resolvedChild = resolve(expandHomePath(childPath));
   const rel = relative(resolvedParent, resolvedChild);
 
   return !rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel);

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 /**
  * Expand a leading tilde to the current user's home directory.
@@ -15,4 +15,15 @@ export function expandHomePath(input: string): string {
   }
 
   return input;
+}
+
+/**
+ * Check if a child path is inside a parent directory.
+ */
+export function isPathInside(parentDir: string, childPath: string): boolean {
+  const resolvedParent = resolve(parentDir);
+  const resolvedChild = resolve(childPath);
+  const rel = relative(resolvedParent, resolvedChild);
+
+  return !rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel);
 }


### PR DESCRIPTION
# Problem

There's no way to block file access completely and allow reads/writes in cwd.

```jsonc
{
  "enabled": true,
  "features": {
    "policies": true,
    "permissionGate": true
  },
  "policies": {
    "rules": [
      {
        "id": "block-outside-cwd",
        "description": "block all reads/writes outside of current working directory",
        "patterns": [{ "pattern": ".*", "regex": true }], // correctly blocks eveything
        "allowedPatterns": [{ "pattern": "**/*" }], // this allows everything back
        "protection": "noAccess",
        "enabled": true,
        "onlyIfExists": false
      }
    ]
  },
  "permissionGate": {
    "requireConfirmation": true,
    "patterns": [{ "pattern": ".*", "regex": true }]
  },
  "version": "0.8.0-20260228"
}
```

# Solution

Add optional file paths filtering to `PatternConfig`.

```jsonc
{
  "enabled": true,
  "features": {
    "policies": true,
    "permissionGate": true
  },
  "policies": {
    "rules": [
      {
        "id": "block-outside-cwd",
        "description": "block all reads/writes outside of current working directory",
        "patterns": [
          {
            "pattern": ".*",
            "regex": true
          }
        ],
        "allowedPatterns": [
          {
            "pattern": ".*",
            "regex": true,
            "pathFilter": [".", "~/code/private/playground/pi-mono/agent"]
          }
        ],
        "protection": "noAccess",
        "enabled": true,
        "onlyIfExists": false
      }
    ]
  },
  "permissionGate": {
    "requireConfirmation": true,
    "patterns": [
      {
        "pattern": ".*",
        "regex": true
      }
    ]
  },
  "version": "0.9.0-20260327",
  "applyBuiltinDefaults": true,
  "onboarding": {
    "completed": true,
    "completedAt": "2026-04-04T17:21:38.540Z",
    "version": "0.9.0-20260327"
  }
}
```