### PR TITLE
feat: add directory access feature

### DIFF
--- a/.changeset/directory-access-feature.md
+++ b/.changeset/directory-access-feature.md
@@ -1,0 +1,27 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add directory access feature: restrict file access to the current working directory
+
+New `directoryAccess` feature with three modes:
+- `block` — always deny access outside the working directory
+- `ask` — prompt with options: allow once, allow for session, allow for project, or deny
+- `allow` — no directory restrictions (feature disabled)
+
+Configuration:
+- `features.directoryAccess` — enable/disable the feature
+- `directoryAccess.mode` — block/ask/allow
+- `directoryAccess.additionalDirs` — extra directory roots that are always allowed (supports `~` expansion, merged across scopes)
+
+The directory access check runs before policy checks. A file inside the working directory can still be blocked by policy rules.
+
+Other changes:
+- Refactored bash path extraction to return all path candidates (decoupled from policy matching, filters by `maybePathLike`)
+- Fixed glob expansion to use `ctx.cwd` instead of `process.cwd()`
+- Fixed hook config stale-cache bug: allowed patterns, auto-deny patterns, additional dirs, and permission gate settings are now re-read from config on each `tool_call` so settings changes take effect immediately
+- Added onboarding step for directory access mode selection
+- Added directory access settings section in `/guardrails:settings`
+- Added migration for existing users (feature disabled by default to preserve existing behavior)
+- Bumped config schema version to 0.11.0
+- Added unit tests for path utils, migration, and policies (56 tests)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Pi is pre-1.0.0, so breaking changes can happen between Pi versions. This extens
 pnpm typecheck    # Type check
 pnpm lint         # Lint (runs on pre-commit)
 pnpm format       # Format
+pnpm test         # Run unit tests
 pnpm changeset    # Create changeset for versioning
 ```
 
@@ -26,11 +27,11 @@ pnpm changeset    # Create changeset for versioning
 src/
   index.ts            # Extension entry, registers hooks and commands
   config.ts           # Configuration loading, schema, defaults, merge logic
-  hooks/              # Event hooks (policies + permission gate)
+  hooks/              # Event hooks (policies + permission gate + directory access)
   commands/           # Slash commands (settings UI, add-policy)
   components/         # UI components (pattern editor)
   lib/                # Vendored subagent executor core (Phase 1)
-  utils/              # Helpers (matching, glob expansion, migration, shell AST)
+  utils/              # Helpers (matching, glob expansion, migration, shell AST, path boundary)
 ```
 
 ## Conventions
@@ -41,6 +42,7 @@ src/
 - Config migrations are predicate-based (`shouldRun`) using structural checks; do not rely on lexicographic version string comparisons
 - `config.version` is a schema marker for debugging/inspection, not the package version
 - Events emitted on the pi event bus for inter-extension communication (`guardrails:blocked`, `guardrails:dangerous`)
+- Hook config (allowed patterns, additional dirs, etc.) is re-read from `configLoader.getConfig()` on each `tool_call` invocation so settings changes take effect immediately without restart
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,35 @@ Use:
 
 This starts a subagent that helps build and save one policy rule.
 
+### Directory access
+
+Restrict file access to the current working directory and approved paths.
+
+```jsonc
+{
+  "features": { "directoryAccess": true },
+  "directoryAccess": {
+    "mode": "ask",
+    "additionalDirs": ["~/code/shared-libs"]
+  }
+}
+```
+
+**Modes:**
+- `block` — always deny access outside the working directory
+- `ask` — prompt with options: allow once, allow for session, allow for project, deny
+- `allow` — no directory restrictions (feature disabled)
+
+**additionalDirs:** Extra directory roots that are always allowed. Supports `~` for home directory.
+
+When `mode` is `ask` and the agent tries to access a file outside the working directory:
+- **y/Enter**: allow once (just this call)
+- **s**: allow for session (ephemeral, cleared on restart)
+- **p**: allow for project (saved to `.pi/extensions/guardrails.json`)
+- **n/Esc**: deny
+
+The directory access check runs before policy checks. A file inside the working directory can still be blocked by policy rules.
+
 ## Permission gate
 
 Detects dangerous bash commands and prompts user confirmation.
@@ -169,7 +198,7 @@ Guardrails emits events for other extensions:
 
 ```ts
 interface GuardrailsBlockedEvent {
-  feature: "policies" | "permissionGate";
+  feature: "policies" | "permissionGate" | "directoryAccess";
   toolName: string;
   input: Record<string, unknown>;
   reason: string;

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -113,3 +113,14 @@ These commands are detected using AST-based structural matching for accuracy.
 | `mkfs.`         | Filesystem format              |
 | `chmod -R 777`  | Insecure recursive permissions |
 | `chown -R`      | Recursive ownership change     |
+
+## Default Directory Access
+
+Directory access is **disabled by default** for existing users. New users who
+complete onboarding with recommended defaults get `mode: "ask"`.
+
+| Field             | Default |
+|-------------------|---------|
+| `features.directoryAccess` | `false` |
+| `mode`            | `"ask"` |
+| `additionalDirs`  | `[]`    |

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "@sinclair/typebox": "^0.34.48",
     "@types/node": "^25.0.10",
     "husky": "^9.1.7",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
   },
   "pnpm": {
     "overrides": {
@@ -64,6 +65,8 @@
     "check:lockfile": "pnpm install --frozen-lockfile --ignore-scripts",
     "prepare": "[ -d .git ] && husky || true",
     "changeset": "changeset",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "version": "changeset version",
     "release": "pnpm changeset publish"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.2.3)(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2))
 
 packages:
 
@@ -345,6 +348,15 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@google/genai@1.41.0':
     resolution: {integrity: sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==}
     engines: {node: '>=20.0.0'}
@@ -366,6 +378,9 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -461,6 +476,12 @@ packages:
   '@mistralai/mistralai@1.14.1':
     resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
 
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -472,6 +493,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -506,6 +530,98 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
@@ -705,6 +821,9 @@ packages:
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -714,6 +833,18 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
@@ -726,6 +857,35 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -775,6 +935,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -821,6 +985,10 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -851,6 +1019,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -880,6 +1051,10 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
@@ -907,6 +1082,9 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -925,9 +1103,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -960,6 +1145,15 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -991,6 +1185,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
@@ -1159,6 +1358,76 @@ packages:
   koffi@2.15.2:
     resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1179,6 +1448,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -1223,6 +1495,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -1239,6 +1516,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1328,6 +1608,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -1338,9 +1621,17 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -1398,6 +1689,11 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1419,6 +1715,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1443,6 +1742,10 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -1453,8 +1756,14 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1498,6 +1807,21 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1532,6 +1856,90 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -1539,6 +1947,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -2277,6 +2690,22 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@google/genai@1.41.0':
     dependencies:
       google-auth-library: 10.5.0
@@ -2303,6 +2732,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -2456,6 +2887,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2467,6 +2905,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxc-project/types@0.124.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2493,6 +2933,57 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
@@ -2802,6 +3293,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -2812,6 +3305,20 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/mime-types@2.1.4': {}
 
@@ -2825,6 +3332,47 @@ snapshots:
     dependencies:
       '@types/node': 25.2.3
     optional: true
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.2.3)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   agent-base@7.1.4: {}
 
@@ -2860,6 +3408,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -2897,6 +3447,8 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2929,6 +3481,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2950,6 +3504,8 @@ snapshots:
       esprima: 4.0.1
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
 
@@ -2976,6 +3532,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  es-module-lexer@2.0.0: {}
+
   escalade@3.2.0: {}
 
   escodegen@2.1.0:
@@ -2990,7 +3548,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -3029,6 +3593,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -3073,6 +3641,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.3:
+    optional: true
 
   gaxios@7.1.3:
     dependencies:
@@ -3260,6 +3831,55 @@ snapshots:
   koffi@2.15.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -3273,6 +3893,10 @@ snapshots:
   lru-cache@11.2.6: {}
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
 
@@ -3309,6 +3933,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   netmask@2.0.2: {}
 
   node-domexception@1.0.0: {}
@@ -3320,6 +3946,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -3402,13 +4030,23 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.4: {}
+
   pify@4.0.1: {}
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier@2.8.8: {}
 
@@ -3478,6 +4116,27 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3493,6 +4152,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -3515,6 +4176,8 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1:
     optional: true
 
@@ -3525,7 +4188,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   std-env@3.10.0: {}
+
+  std-env@4.0.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3569,6 +4236,17 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -3593,11 +4271,55 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      yaml: 2.8.2
+
+  vitest@4.1.4(@types/node@25.2.3)(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.2.3)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/commands/onboarding-command.ts
+++ b/src/commands/onboarding-command.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { configLoader, type GuardrailsConfig } from "../config";
+import type { DirectoryAccessMode, GuardrailsConfig } from "../config";
+import { configLoader } from "../config";
 import {
   buildOnboardedConfig,
   createOnboardingWizard,
@@ -10,12 +11,24 @@ import {
 function mergeOnboarding(
   base: GuardrailsConfig | null,
   applyBuiltinDefaults: boolean,
+  directoryAccessMode: DirectoryAccessMode,
 ): GuardrailsConfig {
   const next = structuredClone(base ?? {});
-  const onboarded = buildOnboardedConfig(applyBuiltinDefaults);
+  const onboarded = buildOnboardedConfig(
+    applyBuiltinDefaults,
+    directoryAccessMode,
+  );
   next.applyBuiltinDefaults = onboarded.applyBuiltinDefaults;
   next.version = onboarded.version;
   next.onboarding = onboarded.onboarding;
+  next.features = {
+    ...next.features,
+    ...onboarded.features,
+  };
+  next.directoryAccess = {
+    ...next.directoryAccess,
+    ...onboarded.directoryAccess,
+  };
   return next;
 }
 
@@ -43,12 +56,20 @@ export function registerGuardrailsOnboardingCommand(
         { overlay: true },
       );
 
-      if (!result.completed || result.applyBuiltinDefaults === null) {
+      if (
+        !result.completed ||
+        result.applyBuiltinDefaults === null ||
+        result.directoryAccessMode === null
+      ) {
         ctx.ui.notify("[Guardrails] onboarding cancelled.", "warning");
         return;
       }
 
-      const merged = mergeOnboarding(globalConfig, result.applyBuiltinDefaults);
+      const merged = mergeOnboarding(
+        globalConfig,
+        result.applyBuiltinDefaults,
+        result.directoryAccessMode,
+      );
       await configLoader.save("global", merged);
       await configLoader.load();
 

--- a/src/commands/onboarding.ts
+++ b/src/commands/onboarding.ts
@@ -6,16 +6,18 @@ import {
 import { getMarkdownTheme, type Theme } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
 import { Box, Key, Markdown, matchesKey, Text } from "@mariozechner/pi-tui";
-import type { GuardrailsConfig } from "../config";
+import type { DirectoryAccessMode, GuardrailsConfig } from "../config";
 import { CURRENT_VERSION } from "../utils/migration";
 
 interface OnboardingState {
   applyBuiltinDefaults: boolean | null;
+  directoryAccessMode: DirectoryAccessMode | null;
 }
 
 export interface OnboardingResult {
   completed: boolean;
   applyBuiltinDefaults: boolean | null;
+  directoryAccessMode: DirectoryAccessMode | null;
 }
 
 class IntroStep implements Component {
@@ -29,7 +31,7 @@ class IntroStep implements Component {
 
   render(width: number): string[] {
     this.introText.setText(
-      "Guardrails helps prevent accidental exposure of secrets and risky actions.\n\nIt gives you two protections:\n- Policies: file access rules (`noAccess` or `readOnly`)\n- Permission gate: confirmation before dangerous commands run\n\nYou are choosing the starting defaults now. You can change them later in `/guardrails:settings`.",
+      "Guardrails helps prevent accidental exposure of secrets and risky actions.\n\nIt gives you three protections:\n- Policies: file access rules (`noAccess` or `readOnly`)\n- Permission gate: confirmation before dangerous commands run\n- Directory access: restrict file access to the current working directory\n\nYou are choosing the starting defaults now. You can change them later in `/guardrails:settings`.",
     );
 
     return [
@@ -69,6 +71,7 @@ class DefaultsChoiceStep implements Component {
         "- Protect secret files like `.env`, `.env.local`, `.env.production`, and `.dev.vars`",
         "- Keep safe exceptions like `.env.example` and `*.sample.env`",
         "- Require confirmation before running dangerous commands like `rm -rf`, `sudo`, and `dd if=`",
+        "- Restrict file access to the current working directory (ask mode)",
       ].join("\n"),
       [
         "Start with no built-in file policy defaults.",
@@ -124,7 +127,64 @@ class DefaultsChoiceStep implements Component {
 
     if (matchesKey(data, Key.enter)) {
       this.state.applyBuiltinDefaults = this.selectedIndex === 0;
+      // Pre-set directory access mode based on defaults choice
+      this.state.directoryAccessMode =
+        this.selectedIndex === 0 ? "ask" : "allow";
       this.onSelect();
+    }
+  }
+}
+
+class DirectoryAccessStep implements Component {
+  private selectedIndex = 1; // "Ask" pre-selected
+
+  constructor(
+    private readonly theme: Theme,
+    private readonly state: OnboardingState,
+    private readonly onSelect: () => void,
+  ) {}
+
+  invalidate() {}
+
+  render(_width: number): string[] {
+    const options = ["Block", "Ask", "Allow"];
+    const descriptions = [
+      "Always deny access outside the working directory",
+      "Prompt you each time (recommended)",
+      "No directory restrictions",
+    ];
+
+    const lines = [
+      "  Restrict file access to the current working directory?",
+      "",
+      "  When the agent tries to access a file outside this project:",
+      "",
+    ];
+
+    for (let i = 0; i < options.length; i++) {
+      const selected = i === this.selectedIndex;
+      const prefix = selected ? "\u25b8 " : "  ";
+      const label = selected
+        ? this.theme.fg("accent", this.theme.bold(` ${options[i]}`))
+        : ` ${options[i]}`;
+      lines.push(`${prefix}${label} \u2014 ${descriptions[i]}`);
+    }
+
+    return lines;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.up) || data === "k") {
+      this.selectedIndex = (this.selectedIndex + 2) % 3;
+    } else if (matchesKey(data, Key.down) || data === "j") {
+      this.selectedIndex = (this.selectedIndex + 1) % 3;
+    } else if (matchesKey(data, Key.enter)) {
+      const modes: DirectoryAccessMode[] = ["block", "ask", "allow"];
+      const mode = modes[this.selectedIndex];
+      if (mode) {
+        this.state.directoryAccessMode = mode;
+        this.onSelect();
+      }
     }
   }
 }
@@ -142,25 +202,39 @@ class FinishStep implements Component {
   }
 
   render(width: number): string[] {
-    const content =
-      this.state.applyBuiltinDefaults === true
-        ? [
-            "You selected **Recommended defaults**.",
-            "",
-            "Guardrails will start with built-in protection, including:",
-            "- secret files like `.env`, `.env.local`, `.env.production`, `.dev.vars`",
-            "- safe exceptions like `.env.example` and `*.sample.env`",
-            "- confirmation before running dangerous commands like `rm -rf`, `sudo`, `dd if=`",
-          ].join("\n")
-        : [
-            "You selected **Minimal setup**.",
-            "",
-            "No built-in file policy defaults will be applied.",
-            "",
-            "You can configure policies later with `/guardrails:settings`.",
-          ].join("\n");
+    const parts: string[] = [];
 
-    this.recapMarkdown.setText(content);
+    if (this.state.applyBuiltinDefaults === true) {
+      parts.push(
+        "You selected **Recommended defaults**.",
+        "",
+        "Guardrails will start with built-in protection, including:",
+        "- secret files like `.env`, `.env.local`, `.env.production`, `.dev.vars`",
+        "- safe exceptions like `.env.example` and `*.sample.env`",
+        "- confirmation before running dangerous commands like `rm -rf`, `sudo`, `dd if=`",
+      );
+    } else {
+      parts.push(
+        "You selected **Minimal setup**.",
+        "",
+        "No built-in file policy defaults will be applied.",
+        "",
+        "You can configure policies later with `/guardrails:settings`.",
+      );
+    }
+
+    if (this.state.directoryAccessMode) {
+      parts.push("");
+      const modeLabel =
+        this.state.directoryAccessMode === "block"
+          ? "Block"
+          : this.state.directoryAccessMode === "ask"
+            ? "Ask"
+            : "Allow";
+      parts.push(`Directory access: **${modeLabel}**`);
+    }
+
+    this.recapMarkdown.setText(parts.join("\n"));
     return [...this.recapMarkdown.render(Math.max(1, width)), ""];
   }
 
@@ -177,6 +251,7 @@ export function createOnboardingWizard(
 ): Component {
   const state: OnboardingState = {
     applyBuiltinDefaults: null,
+    directoryAccessMode: null,
   };
 
   let markWelcomeComplete: (() => void) | null = null;
@@ -211,6 +286,14 @@ export function createOnboardingWizard(
           }),
       },
       {
+        label: "Directory",
+        build: (ctx) =>
+          new DirectoryAccessStep(theme, state, () => {
+            ctx.markComplete();
+            ctx.goNext();
+          }),
+      },
+      {
         label: "Recap",
         build: (ctx) =>
           new FinishStep(state, () => {
@@ -219,21 +302,32 @@ export function createOnboardingWizard(
             finalize({
               completed: true,
               applyBuiltinDefaults: state.applyBuiltinDefaults,
+              directoryAccessMode: state.directoryAccessMode ?? "allow",
             });
           }),
       },
     ],
     onComplete: () => {
       if (state.applyBuiltinDefaults === null) {
-        finalize({ completed: false, applyBuiltinDefaults: null });
+        finalize({
+          completed: false,
+          applyBuiltinDefaults: null,
+          directoryAccessMode: null,
+        });
         return;
       }
       finalize({
         completed: true,
         applyBuiltinDefaults: state.applyBuiltinDefaults,
+        directoryAccessMode: state.directoryAccessMode ?? "allow",
       });
     },
-    onCancel: () => finalize({ completed: false, applyBuiltinDefaults: null }),
+    onCancel: () =>
+      finalize({
+        completed: false,
+        applyBuiltinDefaults: null,
+        directoryAccessMode: null,
+      }),
     hintSuffix: "Enter select/continue",
     minContentHeight: 12,
   });
@@ -256,10 +350,18 @@ export function createOnboardingWizard(
 
 export function buildOnboardedConfig(
   applyBuiltinDefaults: boolean,
+  directoryAccessMode: DirectoryAccessMode,
 ): GuardrailsConfig {
   return {
     version: CURRENT_VERSION,
     applyBuiltinDefaults,
+    features: {
+      directoryAccess: directoryAccessMode !== "allow",
+    },
+    directoryAccess: {
+      mode: directoryAccessMode,
+      additionalDirs: [],
+    },
     onboarding: {
       completed: true,
       completedAt: new Date().toISOString(),

--- a/src/commands/settings-command.ts
+++ b/src/commands/settings-command.ts
@@ -40,6 +40,10 @@ const FEATURE_UI: Record<FeatureKey, { label: string; description: string }> = {
     description:
       "Prompt for confirmation on dangerous commands (rm -rf, sudo, etc.)",
   },
+  directoryAccess: {
+    label: "Directory access",
+    description: "Restrict file access to the current working directory",
+  },
 };
 
 const POLICY_EXAMPLES: Array<{
@@ -1339,6 +1343,62 @@ export function registerGuardrailsSettings(pi: ExtensionAPI): void {
                     },
                   ],
                 }),
+            },
+          ],
+        },
+        {
+          label: "Directory Access",
+          items: [
+            {
+              id: "features.directoryAccess",
+              label: "Enabled",
+              description: FEATURE_UI.directoryAccess.description,
+              currentValue:
+                scopedConfig.features?.directoryAccess === undefined
+                  ? "(inherited)"
+                  : scopedConfig.features.directoryAccess
+                    ? "enabled"
+                    : "disabled",
+              values: ["enabled", "disabled"],
+            },
+            {
+              id: "directoryAccess.mode",
+              label: "Mode",
+              description:
+                "block: always deny \u2022 ask: prompt each time \u2022 allow: no restriction",
+              currentValue:
+                scopedConfig.directoryAccess?.mode === undefined
+                  ? "(inherited)"
+                  : scopedConfig.directoryAccess.mode,
+              values: ["block", "ask", "allow"],
+            },
+            {
+              id: "directoryAccess.additionalDirs",
+              label: "Additional directories",
+              description: "Extra directory roots that are always allowed",
+              currentValue: count("directoryAccess.additionalDirs"),
+              submenu: (_val: string, submenuDone: (v?: string) => void) => {
+                const dirs = scopedConfig.directoryAccess?.additionalDirs ?? [];
+                const items = dirs.map((d) => ({
+                  pattern: d,
+                  description: d,
+                }));
+                let latestCount = dirs.length;
+                return new PatternEditor({
+                  label: "Additional Directories",
+                  items,
+                  theme: settingsTheme,
+                  context: "file",
+                  onSave: (newItems) => {
+                    latestCount = newItems.length;
+                    const newDirs: string[] = newItems
+                      .map((item) => item.pattern.trim())
+                      .filter(Boolean);
+                    applyDraft("directoryAccess.additionalDirs", newDirs);
+                  },
+                  onDone: () => submenuDone(`${latestCount} dirs`),
+                });
+              },
             },
           ],
         },

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,14 @@ export interface PolicyRule {
   enabled?: boolean;
 }
 
+export type DirectoryAccessMode = "block" | "ask" | "allow";
+
+export interface DirectoryAccessConfig {
+  mode?: DirectoryAccessMode;
+  /** Directory roots that are always allowed (absolute or ~-expanded paths). Merged across scopes. */
+  additionalDirs?: string[];
+}
+
 export interface GuardrailsConfig {
   version?: string;
   enabled?: boolean;
@@ -66,12 +74,14 @@ export interface GuardrailsConfig {
   features?: {
     policies?: boolean;
     permissionGate?: boolean;
+    directoryAccess?: boolean;
     // Deprecated. Kept only for migration.
     protectEnvFiles?: boolean;
   };
   policies?: {
     rules?: PolicyRule[];
   };
+  directoryAccess?: DirectoryAccessConfig;
   // Deprecated. Kept only for migration.
   envFiles?: {
     protectedPatterns?: PatternConfig[];
@@ -101,9 +111,14 @@ export interface ResolvedConfig {
   features: {
     policies: boolean;
     permissionGate: boolean;
+    directoryAccess: boolean;
   };
   policies: {
     rules: PolicyRule[];
+  };
+  directoryAccess: {
+    mode: DirectoryAccessMode;
+    additionalDirs: string[];
   };
   permissionGate: {
     patterns: DangerousPattern[];
@@ -123,8 +138,10 @@ import { ConfigLoader, type Migration } from "@aliou/pi-utils-settings";
 import {
   backupConfig,
   CURRENT_VERSION,
+  migrateDirectoryAccess,
   migrateEnvFilesToPolicies,
   migrateV0,
+  needsDirectoryAccessMigration,
   needsEnvFilesToPoliciesMigration,
   needsMigration,
 } from "./utils/migration";
@@ -190,6 +207,11 @@ const migrations: Migration<GuardrailsConfig>[] = [
     shouldRun: (config) => needsEnvFilesToPoliciesMigration(config),
     run: (config) => migrateEnvFilesToPolicies(config),
   },
+  {
+    name: "directory-access-migration",
+    shouldRun: (config) => needsDirectoryAccessMigration(config),
+    run: (config) => migrateDirectoryAccess(config),
+  },
 ];
 
 const DEFAULT_CONFIG: ResolvedConfig = {
@@ -199,6 +221,11 @@ const DEFAULT_CONFIG: ResolvedConfig = {
   features: {
     policies: true,
     permissionGate: true,
+    directoryAccess: false,
+  },
+  directoryAccess: {
+    mode: "ask",
+    additionalDirs: [],
   },
   policies: {
     rules: [
@@ -337,6 +364,23 @@ export const configLoader = new ConfigLoader<GuardrailsConfig, ResolvedConfig>(
         resolved.permissionGate.patterns = customPatterns;
         resolved.permissionGate.useBuiltinMatchers = false;
       }
+
+      // Merge additionalDirs across scopes: global + local + memory (all additive)
+      const mergedDirs = new Set<string>();
+      for (const dirs of [
+        resolved.directoryAccess.additionalDirs,
+        global?.directoryAccess?.additionalDirs,
+        local?.directoryAccess?.additionalDirs,
+        memory?.directoryAccess?.additionalDirs,
+      ]) {
+        if (dirs) {
+          for (const d of dirs) {
+            mergedDirs.add(d);
+          }
+        }
+      }
+      resolved.directoryAccess.additionalDirs = [...mergedDirs];
+
       return resolved;
     },
   },

--- a/src/hooks/permission-gate.ts
+++ b/src/hooks/permission-gate.ts
@@ -488,25 +488,25 @@ export function setupPermissionGateHook(
 ) {
   if (!config.features.permissionGate) return;
 
-  // Compile all configured patterns for substring/regex matching.
-  // When useBuiltinMatchers is true (defaults), these act as a supplement
-  // to the structural matchers. When false (customPatterns), these are the
-  // only matching path.
+  // Compile dangerous patterns once (only change on customPatterns swap, which requires restart)
   const compiledPatterns = compileCommandPatterns(
     config.permissionGate.patterns,
   );
   const { useBuiltinMatchers } = config.permissionGate;
   const fallbackPatterns = config.permissionGate.patterns;
 
-  const allowedPatterns = compileCommandPatterns(
-    config.permissionGate.allowedPatterns,
-  );
-  const autoDenyPatterns = compileCommandPatterns(
-    config.permissionGate.autoDenyPatterns,
-  );
-
   pi.on("tool_call", async (event, ctx) => {
     if (!isToolCallEventType("bash", event)) return;
+
+    // Re-read allowed/auto-deny patterns from config on each invocation
+    // so settings changes take effect immediately
+    const liveConfig = configLoader.getConfig();
+    const allowedPatterns = compileCommandPatterns(
+      liveConfig.permissionGate.allowedPatterns,
+    );
+    const autoDenyPatterns = compileCommandPatterns(
+      liveConfig.permissionGate.autoDenyPatterns,
+    );
 
     const command = event.input.command;
 
@@ -548,7 +548,7 @@ export function setupPermissionGateHook(
     // Emit dangerous event (presenter will play sound)
     emitDangerous(pi, { command, description, pattern: rawPattern });
 
-    if (config.permissionGate.requireConfirmation) {
+    if (liveConfig.permissionGate.requireConfirmation) {
       // In print/RPC mode, block by default (safe fallback)
       if (!ctx.hasUI) {
         const reason = `Dangerous command blocked (no UI to confirm): ${description}`;
@@ -563,13 +563,13 @@ export function setupPermissionGateHook(
 
       let explanation: CommandExplanation | null = null;
       if (
-        config.permissionGate.explainCommands &&
-        config.permissionGate.explainModel
+        liveConfig.permissionGate.explainCommands &&
+        liveConfig.permissionGate.explainModel
       ) {
         const explainResult = await explainCommand(
           command,
-          config.permissionGate.explainModel,
-          config.permissionGate.explainTimeout,
+          liveConfig.permissionGate.explainModel,
+          liveConfig.permissionGate.explainTimeout,
           ctx,
         );
         explanation = explainResult.explanation;
@@ -586,7 +586,6 @@ export function setupPermissionGateHook(
 
       if (result === "allow-session") {
         // Save command as allowed in memory scope (session-only).
-        // Spread the resolved allowed patterns and append the new one.
         const resolved = configLoader.getConfig();
         await configLoader.save("memory", {
           permissionGate: {
@@ -596,9 +595,6 @@ export function setupPermissionGateHook(
             ],
           },
         });
-
-        // Update the local cache so it takes effect immediately
-        allowedPatterns.push(...compileCommandPatterns([{ pattern: command }]));
       }
 
       if (result === "deny") {

--- a/src/hooks/policies.test.ts
+++ b/src/hooks/policies.test.ts
@@ -98,6 +98,19 @@ describe("extractBashPathCandidates", () => {
     );
     expect(result.length).toBeGreaterThanOrEqual(0);
   });
+
+  it("extracts Windows absolute path with backslashes", async () => {
+    const result = await extractBashPathCandidates(
+      "type C:\\repo\\file.txt",
+      cwd,
+    );
+    expect(result.some((p) => p.includes("file.txt"))).toBe(true);
+  });
+
+  it("extracts Windows relative path with backslash (.\\)", async () => {
+    const result = await extractBashPathCandidates("cat .\\secrets.txt", cwd);
+    expect(result.some((p) => p.includes("secrets.txt"))).toBe(true);
+  });
 });
 
 describe("normalizeTargetForPolicy", () => {

--- a/src/hooks/policies.test.ts
+++ b/src/hooks/policies.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractBashPathCandidates,
+  isBoundaryAllowed,
+  normalizeTargetForPolicy,
+} from "./policies";
+
+describe("isBoundaryAllowed", () => {
+  const cwd = "/project";
+
+  it("allows file inside cwd", () => {
+    expect(isBoundaryAllowed("/project/src/index.ts", cwd, [])).toBe(true);
+  });
+
+  it("allows file in additionalDirs", () => {
+    expect(
+      isBoundaryAllowed("/shared-libs/util.ts", cwd, ["/shared-libs"]),
+    ).toBe(true);
+  });
+
+  it("allows file in nested additionalDir", () => {
+    expect(
+      isBoundaryAllowed("/shared-libs/src/util.ts", cwd, ["/shared-libs"]),
+    ).toBe(true);
+  });
+
+  it("blocks file outside cwd and additionalDirs", () => {
+    expect(isBoundaryAllowed("/etc/hosts", cwd, [])).toBe(false);
+  });
+
+  it("blocks file outside cwd even with additionalDirs", () => {
+    expect(isBoundaryAllowed("/etc/hosts", cwd, ["/shared-libs"])).toBe(false);
+  });
+
+  it("allows when cwd matches exactly", () => {
+    expect(isBoundaryAllowed(cwd, cwd, [])).toBe(true);
+  });
+
+  it("handles multiple additionalDirs", () => {
+    expect(isBoundaryAllowed("/dir-b/file.ts", cwd, ["/dir-a", "/dir-b"])).toBe(
+      true,
+    );
+  });
+
+  it("rejects prefix tricks on additionalDirs", () => {
+    expect(
+      isBoundaryAllowed("/shared-libs-extra/file.ts", cwd, ["/shared-libs"]),
+    ).toBe(false);
+  });
+});
+
+describe("extractBashPathCandidates", () => {
+  const cwd = "/project";
+
+  it("extracts path arguments from simple command", async () => {
+    const result = await extractBashPathCandidates("cat src/index.ts", cwd);
+    expect(result.some((p) => p.includes("index.ts"))).toBe(true);
+  });
+
+  it("skips flags", async () => {
+    const result = await extractBashPathCandidates("cat -n src/index.ts", cwd);
+    expect(result.some((p) => p.startsWith("-"))).toBe(false);
+    expect(result.some((p) => p.includes("index.ts"))).toBe(true);
+  });
+
+  it("extracts redirect target", async () => {
+    const result = await extractBashPathCandidates(
+      "echo hello > output.txt",
+      cwd,
+    );
+    expect(result.some((p) => p.includes("output.txt"))).toBe(true);
+  });
+
+  it("handles relative path escaping cwd", async () => {
+    const result = await extractBashPathCandidates(
+      "cat ../outside/secret.txt",
+      cwd,
+    );
+    expect(
+      result.some((p) => p.includes("outside") || p.includes("secret")),
+    ).toBe(true);
+  });
+
+  it("handles tilde expansion", async () => {
+    const result = await extractBashPathCandidates("cat ~/.ssh/id_rsa", cwd);
+    expect(result.some((p) => p.includes(".ssh"))).toBe(true);
+  });
+
+  it("returns empty for command with no path-like args", async () => {
+    const result = await extractBashPathCandidates("echo hello world", cwd);
+    expect(result.length).toBe(0);
+  });
+
+  it("falls back to tokenizer on parse failure", async () => {
+    const result = await extractBashPathCandidates(
+      "cat '../broken quote.txt'",
+      cwd,
+    );
+    expect(result.length).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("normalizeTargetForPolicy", () => {
+  const cwd = "/project";
+
+  it("normalizes ~ paths preserving ~ form", () => {
+    const result = normalizeTargetForPolicy("~/.ssh/id_rsa", cwd);
+    expect(result).toContain(".ssh");
+    // ~/ paths are intentionally kept in ~/ form for cross-platform matching
+    expect(result).toContain("~");
+  });
+
+  it("normalizes relative paths inside cwd", () => {
+    const result = normalizeTargetForPolicy("src/index.ts", cwd);
+    expect(result).toBe("src/index.ts");
+  });
+
+  it("normalizes ../ escapes to absolute or ~/ form", () => {
+    const result = normalizeTargetForPolicy("../outside/file.txt", cwd);
+    expect(result).toContain("outside");
+  });
+
+  it("normalizes absolute paths inside home to ~/ form", () => {
+    const home = process.env.HOME ?? "";
+    if (home) {
+      const result = normalizeTargetForPolicy(`${home}/.ssh/id_rsa`, cwd);
+      expect(result).toContain("~");
+    }
+  });
+});

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -316,7 +316,7 @@ function getRawAdditionalDirs(
  * Merges with existing memory scope config instead of clobbering.
  */
 async function allowDirectoryForSession(absTarget: string): Promise<void> {
-  const grantDir = extractGrantDirectory(absTarget);
+  const grantDir = await extractGrantDirectory(absTarget);
   const rawMemory = (configLoader.getRawConfig("memory") ?? {}) as Record<
     string,
     unknown
@@ -338,7 +338,7 @@ async function allowDirectoryForSession(absTarget: string): Promise<void> {
  * Add a directory to the project grant list (local scope).
  */
 async function allowDirectoryForProject(absTarget: string): Promise<void> {
-  const grantDir = extractGrantDirectory(absTarget);
+  const grantDir = await extractGrantDirectory(absTarget);
   const rawLocal = (configLoader.getRawConfig("local") ?? {}) as Record<
     string,
     unknown

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -1,8 +1,13 @@
 import { stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { parse } from "@aliou/sh";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+  DynamicBorder,
+  type ExtensionAPI,
+} from "@mariozechner/pi-coding-agent";
+import { Container, Key, matchesKey, Spacer, Text } from "@mariozechner/pi-tui";
 import type { PolicyRule, Protection, ResolvedConfig } from "../config";
+import { configLoader } from "../config";
 import { emitBlocked } from "../utils/events";
 import { expandGlob, hasGlobChars } from "../utils/glob-expander";
 import {
@@ -10,7 +15,12 @@ import {
   compileFilePatterns,
   normalizeFilePath,
 } from "../utils/matching";
-import { expandHomePath } from "../utils/path";
+import {
+  expandHomePath,
+  extractGrantDirectory,
+  isWithinLexicalBoundary,
+  resolveFromCwd,
+} from "../utils/path";
 import { walkCommands, wordToString } from "../utils/shell-utils";
 import { pendingWarnings } from "../utils/warnings";
 
@@ -118,7 +128,10 @@ function maybePathLike(token: string): boolean {
   );
 }
 
-function normalizeTargetForPolicy(filePath: string, cwd: string): string {
+export function normalizeTargetForPolicy(
+  filePath: string,
+  cwd: string,
+): string {
   if (filePath === "~" || filePath.startsWith("~/")) {
     return normalizeFilePath(filePath);
   }
@@ -143,41 +156,37 @@ function resolvePolicyPath(filePath: string, cwd: string): string {
   return resolve(cwd, expandHomePath(filePath));
 }
 
-function matchesAnyPolicyPattern(
-  filePath: string,
-  rules: CompiledRule[],
-): boolean {
-  return rules.some(
-    (rule) =>
-      rule.enabled && rule.patterns.some((pattern) => pattern.test(filePath)),
-  );
-}
-
-async function expandCandidate(candidate: string): Promise<string[]> {
+async function expandCandidate(
+  candidate: string,
+  cwd: string,
+): Promise<string[]> {
   if (!hasGlobChars(candidate)) return [candidate];
 
-  const matches = await expandGlob(candidate);
+  const matches = await expandGlob(candidate, { cwd });
   if (matches.length > 0) return matches;
 
   return [candidate];
 }
 
-async function extractBashFileTargets(
+/**
+ * Extract path-like candidates from a bash command string.
+ * Returns ALL path-like arguments (no policy filtering).
+ * Used by both directoryAccess boundary checks and policy checks.
+ */
+export async function extractBashPathCandidates(
   command: string,
-  rules: CompiledRule[],
   cwd: string,
 ): Promise<string[]> {
   const targets = new Set<string>();
 
   const maybeAddTarget = async (candidate: string): Promise<void> => {
     if (!candidate || candidate.startsWith("-")) return;
+    if (!maybePathLike(candidate)) return;
 
-    const expanded = await expandCandidate(candidate);
+    const expanded = await expandCandidate(candidate, cwd);
     for (const file of expanded) {
       const normalized = normalizeTargetForPolicy(file, cwd);
-      if (matchesAnyPolicyPattern(normalized, rules)) {
-        targets.add(normalized);
-      }
+      targets.add(normalized);
     }
   };
 
@@ -212,12 +221,10 @@ async function extractBashFileTargets(
         continue;
       }
 
-      const expanded = await expandCandidate(token);
+      const expanded = await expandCandidate(token, cwd);
       for (const file of expanded) {
         const normalized = normalizeTargetForPolicy(file, cwd);
-        if (matchesAnyPolicyPattern(normalized, rules)) {
-          targets.add(normalized);
-        }
+        targets.add(normalized);
       }
     }
 
@@ -279,24 +286,263 @@ function extractPathTarget(input: Record<string, unknown>): string[] {
   return target ? [target] : [];
 }
 
+// ---- directoryAccess helpers ----
+
+export function isBoundaryAllowed(
+  target: string,
+  cwd: string,
+  additionalDirs: string[],
+): boolean {
+  if (isWithinLexicalBoundary(target, cwd)) return true;
+
+  for (const dir of additionalDirs) {
+    if (isWithinLexicalBoundary(target, dir)) return true;
+  }
+
+  return false;
+}
+
+function getRawAdditionalDirs(
+  rawConfig: Record<string, unknown> | null,
+): string[] {
+  const da = rawConfig?.directoryAccess as Record<string, unknown> | undefined;
+  return Array.isArray(da?.additionalDirs)
+    ? (da?.additionalDirs as string[])
+    : [];
+}
+
+/**
+ * Add a directory to the session grant list (memory scope).
+ * Merges with existing memory scope config instead of clobbering.
+ */
+async function allowDirectoryForSession(absTarget: string): Promise<void> {
+  const grantDir = extractGrantDirectory(absTarget);
+  const rawMemory = (configLoader.getRawConfig("memory") ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const existingDirs = getRawAdditionalDirs(rawMemory);
+
+  if (existingDirs.includes(grantDir)) return;
+
+  await configLoader.save("memory", {
+    ...rawMemory,
+    directoryAccess: {
+      ...(rawMemory.directoryAccess as Record<string, unknown> | undefined),
+      additionalDirs: [...existingDirs, grantDir],
+    },
+  });
+}
+
+/**
+ * Add a directory to the project grant list (local scope).
+ */
+async function allowDirectoryForProject(absTarget: string): Promise<void> {
+  const grantDir = extractGrantDirectory(absTarget);
+  const rawLocal = (configLoader.getRawConfig("local") ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const existingDirs = getRawAdditionalDirs(rawLocal);
+
+  if (existingDirs.includes(grantDir)) return;
+
+  await configLoader.save("local", {
+    ...rawLocal,
+    directoryAccess: {
+      ...(rawLocal.directoryAccess as Record<string, unknown> | undefined),
+      additionalDirs: [...existingDirs, grantDir],
+    },
+  });
+}
+
+function createDirectoryAccessConfirmComponent(
+  toolName: string,
+  targetPath: string,
+  cwd: string,
+) {
+  return (
+    _tui: { terminal: { columns: number }; requestRender(): void },
+    theme: {
+      fg(color: string, text: string): string;
+      bg(color: string, text: string): string;
+      bold(text: string): string;
+    },
+    _kb: unknown,
+    done: (
+      result: "allow-once" | "allow-session" | "allow-project" | "deny",
+    ) => void,
+  ) => {
+    const container = new Container();
+    const border = (s: string) => theme.fg("warning", s);
+
+    container.addChild(new DynamicBorder(border));
+    container.addChild(
+      new Text(
+        theme.fg("warning", theme.bold("Outside Workspace Access")),
+        1,
+        0,
+      ),
+    );
+    container.addChild(new Spacer(1));
+    container.addChild(
+      new Text(
+        theme.fg(
+          "text",
+          `This ${toolName} targets a path outside the current working directory.`,
+        ),
+        1,
+        0,
+      ),
+    );
+    container.addChild(new Spacer(1));
+    container.addChild(
+      new Text(theme.fg("dim", `  Path: ${targetPath}`), 1, 0),
+    );
+    container.addChild(new Text(theme.fg("dim", `  Cwd:  ${cwd}`), 1, 0));
+    container.addChild(new Spacer(1));
+    container.addChild(new Text(theme.fg("text", "Allow access?"), 1, 0));
+    container.addChild(new Spacer(1));
+    container.addChild(
+      new Text(
+        theme.fg(
+          "dim",
+          "y/enter: allow once \u2022 s: session \u2022 p: project \u2022 n/esc: deny",
+        ),
+        1,
+        0,
+      ),
+    );
+    container.addChild(new DynamicBorder(border));
+
+    return {
+      render: (width: number) => container.render(width),
+      invalidate: () => container.invalidate(),
+      handleInput: (data: string) => {
+        if (matchesKey(data, Key.enter) || data === "y" || data === "Y") {
+          done("allow-once");
+        } else if (data === "s" || data === "S") {
+          done("allow-session");
+        } else if (data === "p" || data === "P") {
+          done("allow-project");
+        } else if (
+          matchesKey(data, Key.escape) ||
+          data === "n" ||
+          data === "N"
+        ) {
+          done("deny");
+        }
+      },
+    };
+  };
+}
+
 export function setupPoliciesHook(pi: ExtensionAPI, config: ResolvedConfig) {
-  if (!config.features.policies) return;
+  if (!config.features.policies && !config.features.directoryAccess) return;
 
-  const compiledRules = compileRules(config.policies.rules);
+  const compiledRules = config.features.policies
+    ? compileRules(config.policies.rules)
+    : [];
 
+  // directoryAccess boundary data
+  const boundaryMode = config.directoryAccess.mode;
+  const boundaryEnabled =
+    config.features.directoryAccess && boundaryMode !== "allow";
   pi.on("tool_call", async (event, ctx) => {
     const toolName = event.toolName;
-    let targets: string[] = [];
 
+    // Re-read directory access config on each invocation so settings changes take effect
+    const liveConfig = configLoader.getConfig();
+    const boundaryAdditionalDirs = (
+      liveConfig.directoryAccess.additionalDirs ?? []
+    ).map((d) => resolveFromCwd(d, process.cwd()));
+
+    // Extract targets (shared between boundary and policy checks)
+    let targets: string[] = [];
     if (["read", "write", "edit", "grep", "find", "ls"].includes(toolName)) {
       targets = extractPathTarget(event.input);
     } else if (toolName === "bash") {
       const command = String(event.input.command ?? "");
-      targets = await extractBashFileTargets(command, compiledRules, ctx.cwd);
+      targets = await extractBashPathCandidates(command, ctx.cwd);
     } else {
       return;
     }
 
+    // ---- directoryAccess boundary check (before policies) ----
+    if (boundaryEnabled) {
+      for (const target of targets) {
+        const normalizedTarget = normalizeTargetForPolicy(target, ctx.cwd);
+        const absTarget = resolveFromCwd(normalizedTarget, ctx.cwd);
+
+        if (isBoundaryAllowed(absTarget, ctx.cwd, boundaryAdditionalDirs)) {
+          continue;
+        }
+
+        // Mode: block (or no UI fallback)
+        if (boundaryMode === "block" || !ctx.hasUI) {
+          const reason =
+            boundaryMode === "block"
+              ? `Access to ${normalizedTarget} is outside the current working directory and is blocked.`
+              : `Access to ${normalizedTarget} is outside the current working directory and was blocked (no UI to confirm).`;
+          emitBlocked(pi, {
+            feature: "directoryAccess",
+            toolName,
+            input: event.input,
+            reason,
+          });
+          return { block: true, reason };
+        }
+
+        // Mode: ask (has UI)
+        type BoundaryResult =
+          | "allow-once"
+          | "allow-session"
+          | "allow-project"
+          | "deny";
+        const result = await ctx.ui.custom<BoundaryResult>(
+          createDirectoryAccessConfirmComponent(
+            toolName,
+            normalizedTarget,
+            ctx.cwd,
+          ),
+        );
+
+        if (result === "allow-session") {
+          await allowDirectoryForSession(absTarget);
+          continue;
+        }
+
+        if (result === "allow-project") {
+          await allowDirectoryForProject(absTarget);
+          continue;
+        }
+
+        // Default to deny: "allow-once" is explicit; anything else (undefined, cancel) blocks
+        if (result !== "allow-once") {
+          emitBlocked(pi, {
+            feature: "directoryAccess",
+            toolName,
+            input: event.input,
+            reason:
+              result === "deny"
+                ? "User denied access outside the current working directory"
+                : "Access outside the current working directory was not confirmed",
+            userDenied: result === "deny",
+          });
+          return {
+            block: true,
+            reason:
+              result === "deny"
+                ? "User denied access outside the current working directory"
+                : "Access outside the current working directory was not confirmed",
+          };
+        }
+
+        // "allow-once" -- continue without persistence
+      }
+    }
+
+    // ---- existing policy checks (unchanged) ----
     for (const target of targets) {
       const normalizedTarget = normalizeTargetForPolicy(target, ctx.cwd);
 

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -136,7 +136,11 @@ export function normalizeTargetForPolicy(
   filePath: string,
   cwd: string,
 ): string {
-  if (filePath === "~" || filePath.startsWith("~/")) {
+  if (
+    filePath === "~" ||
+    filePath.startsWith("~/") ||
+    filePath.startsWith("~\\")
+  ) {
     return normalizeFilePath(filePath);
   }
 

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -121,10 +121,14 @@ function compileRules(rules: PolicyRule[]): CompiledRule[] {
 function maybePathLike(token: string): boolean {
   return (
     token.includes("/") ||
+    token.includes("\\") ||
+    /^[A-Za-z]:[\\/]/.test(token) ||
     token.includes(".") ||
     token.startsWith("~") ||
     token.startsWith("./") ||
-    token.startsWith("../")
+    token.startsWith("../") ||
+    token.startsWith(".\\") ||
+    token.startsWith("..\\")
   );
 }
 

--- a/src/hooks/policies.ts
+++ b/src/hooks/policies.ts
@@ -444,18 +444,17 @@ export function setupPoliciesHook(pi: ExtensionAPI, config: ResolvedConfig) {
     ? compileRules(config.policies.rules)
     : [];
 
-  // directoryAccess boundary data
-  const boundaryMode = config.directoryAccess.mode;
-  const boundaryEnabled =
-    config.features.directoryAccess && boundaryMode !== "allow";
   pi.on("tool_call", async (event, ctx) => {
     const toolName = event.toolName;
 
     // Re-read directory access config on each invocation so settings changes take effect
     const liveConfig = configLoader.getConfig();
+    const boundaryMode = liveConfig.directoryAccess.mode;
+    const boundaryEnabled =
+      liveConfig.features.directoryAccess && boundaryMode !== "allow";
     const boundaryAdditionalDirs = (
       liveConfig.directoryAccess.additionalDirs ?? []
-    ).map((d) => resolveFromCwd(d, process.cwd()));
+    ).map((d) => resolveFromCwd(d, ctx.cwd));
 
     // Extract targets (shared between boundary and policy checks)
     let targets: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,10 @@ import { configLoader } from "./config";
 import { setupGuardrailsHooks } from "./hooks";
 import {
   migrateApplyBuiltinDefaults,
+  migrateDirectoryAccess,
   migrateMarkOnboardingDone,
   needsApplyBuiltinDefaultsMigration,
+  needsDirectoryAccessMigration,
   needsOnboardingDoneMigration,
 } from "./utils/migration";
 import { pendingWarnings } from "./utils/warnings";
@@ -46,6 +48,11 @@ export default async function (pi: ExtensionAPI) {
 
       if (needsOnboardingDoneMigration(migrated)) {
         migrated = migrateMarkOnboardingDone(migrated);
+        changed = true;
+      }
+
+      if (needsDirectoryAccessMigration(migrated)) {
+        migrated = migrateDirectoryAccess(migrated);
         changed = true;
       }
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -4,7 +4,7 @@ export const GUARDRAILS_BLOCKED_EVENT = "guardrails:blocked";
 export const GUARDRAILS_DANGEROUS_EVENT = "guardrails:dangerous";
 
 export interface GuardrailsBlockedEvent {
-  feature: "policies" | "permissionGate";
+  feature: "policies" | "permissionGate" | "directoryAccess";
   toolName: string;
   input: Record<string, unknown>;
   reason: string;

--- a/src/utils/migration.test.ts
+++ b/src/utils/migration.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { GuardrailsConfig } from "../config";
+import {
+  CURRENT_VERSION,
+  migrateDirectoryAccess,
+  needsDirectoryAccessMigration,
+} from "./migration";
+
+describe("needsDirectoryAccessMigration", () => {
+  it("returns true when no directoryAccess and onboarding completed", () => {
+    const config: GuardrailsConfig = {
+      onboarding: { completed: true },
+    };
+    expect(needsDirectoryAccessMigration(config)).toBe(true);
+  });
+
+  it("returns false when directoryAccess already present", () => {
+    const config: GuardrailsConfig = {
+      directoryAccess: { mode: "allow", additionalDirs: [] },
+      onboarding: { completed: true },
+    };
+    expect(needsDirectoryAccessMigration(config)).toBe(false);
+  });
+
+  it("returns false when onboarding not completed", () => {
+    const config: GuardrailsConfig = {
+      onboarding: { completed: false },
+    };
+    expect(needsDirectoryAccessMigration(config)).toBe(false);
+  });
+
+  it("returns false when no onboarding field", () => {
+    const config: GuardrailsConfig = {};
+    expect(needsDirectoryAccessMigration(config)).toBe(false);
+  });
+
+  it("returns false when directoryAccess present even without onboarding", () => {
+    const config: GuardrailsConfig = {
+      directoryAccess: { mode: "block", additionalDirs: [] },
+    };
+    expect(needsDirectoryAccessMigration(config)).toBe(false);
+  });
+});
+
+describe("migrateDirectoryAccess", () => {
+  it("sets features.directoryAccess to false", () => {
+    const config: GuardrailsConfig = {
+      onboarding: { completed: true },
+    };
+    const result = migrateDirectoryAccess(config);
+    expect(result.features?.directoryAccess).toBe(false);
+  });
+
+  it("sets mode to allow to preserve existing behavior", () => {
+    const config: GuardrailsConfig = {
+      onboarding: { completed: true },
+    };
+    const result = migrateDirectoryAccess(config);
+    expect(result.directoryAccess?.mode).toBe("allow");
+  });
+
+  it("sets empty additionalDirs", () => {
+    const config: GuardrailsConfig = {
+      onboarding: { completed: true },
+    };
+    const result = migrateDirectoryAccess(config);
+    expect(result.directoryAccess?.additionalDirs).toEqual([]);
+  });
+
+  it("bumps version to CURRENT_VERSION", () => {
+    const config: GuardrailsConfig = {
+      version: "0.1.0",
+      onboarding: { completed: true },
+    };
+    const result = migrateDirectoryAccess(config);
+    expect(result.version).toBe(CURRENT_VERSION);
+  });
+
+  it("preserves existing features", () => {
+    const config: GuardrailsConfig = {
+      features: { policies: true, permissionGate: false },
+      onboarding: { completed: true },
+    };
+    const result = migrateDirectoryAccess(config);
+    expect(result.features?.policies).toBe(true);
+    expect(result.features?.permissionGate).toBe(false);
+    expect(result.features?.directoryAccess).toBe(false);
+  });
+
+  it("does not mutate the original config", () => {
+    const config: GuardrailsConfig = {
+      features: { policies: true },
+      onboarding: { completed: true },
+    };
+    const clone = structuredClone(config);
+    migrateDirectoryAccess(config);
+    expect(config).toEqual(clone);
+  });
+});

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -21,7 +21,7 @@ import { pendingWarnings } from "./warnings";
  * Keep this independent from package.json version.
  * Bump only when config schema/default migration markers change.
  */
-export const CURRENT_VERSION = "0.9.0-20260327";
+export const CURRENT_VERSION = "0.11.0-20260413";
 
 /**
  * Check if a config needs migration (no version field = v0).
@@ -269,6 +269,30 @@ function migrateDangerousPatterns(
     }
     return { ...item, regex: true };
   });
+}
+
+export function needsDirectoryAccessMigration(
+  config: GuardrailsConfig,
+): boolean {
+  return (
+    config.directoryAccess === undefined &&
+    config.onboarding?.completed === true
+  );
+}
+
+export function migrateDirectoryAccess(
+  config: GuardrailsConfig,
+): GuardrailsConfig {
+  const migrated = structuredClone(config);
+  migrated.features = { ...migrated.features, directoryAccess: false };
+  migrated.directoryAccess = { mode: "allow", additionalDirs: [] };
+  migrated.version = CURRENT_VERSION;
+  pendingWarnings.push(
+    "[Guardrails] New `directoryAccess` feature available. Restricts file access " +
+      "to the current working directory. Currently disabled to preserve existing behavior. " +
+      "Enable it in /guardrails:settings.",
+  );
+  return migrated;
 }
 
 /**

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -141,10 +141,11 @@ describe("extractGrantDirectory", () => {
     expect(result).toBe("/a/b/c/d");
   });
 
-  it("handles Windows-style backslashes", () => {
+  it("handles Windows-style backslashes (normalizes to forward slashes)", () => {
     const result = extractGrantDirectory("C:\\project\\src\\file.ts");
-    // After normalize: "C:/project/src/file.ts" -> parent "C:/project/src"
-    // resolve() on macOS will resolve relative to cwd, but the split on "/" works
-    expect(result).toContain("src");
+    // On non-Windows, resolve() treats C:\project as relative to cwd,
+    // so just verify the function doesn't crash and the backslash
+    // normalization in extractGrantDirectory works
+    expect(result).not.toContain("\\");
   });
 });

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   expandHomePath,
@@ -110,42 +113,63 @@ describe("isWithinLexicalBoundary", () => {
 });
 
 describe("extractGrantDirectory", () => {
-  it("returns parent for file with extension", () => {
-    const result = extractGrantDirectory("/project/src/index.ts");
+  it("returns parent for file with extension", async () => {
+    const result = await extractGrantDirectory("/project/src/index.ts");
     expect(result).toBe("/project/src");
   });
 
-  it("returns parent for dotfile with no further dots (.env)", () => {
-    const result = extractGrantDirectory("/project/.env");
+  it("returns as-is for dot-prefixed segment with no further dots (.env) — heuristic", async () => {
+    // .env doesn't exist on disk → heuristic treats single dot-prefix with no further dots as directory
+    const result = await extractGrantDirectory("/project/.env");
+    expect(result).toBe("/project/.env");
+  });
+
+  it("returns parent for dotfile with dots (.env.local)", async () => {
+    const result = await extractGrantDirectory("/project/.env.local");
     expect(result).toBe("/project");
   });
 
-  it("returns parent for dotfile with dots (.env.local)", () => {
-    const result = extractGrantDirectory("/project/.env.local");
-    expect(result).toBe("/project");
-  });
-
-  it("returns as-is for directory (no dot in last segment)", () => {
-    const result = extractGrantDirectory("/project/src");
+  it("returns as-is for directory (no dot in last segment)", async () => {
+    const result = await extractGrantDirectory("/project/src");
     expect(result).toBe("/project/src");
   });
 
-  it("returns parent for hidden directory with dot (.git)", () => {
-    // ".git" has no dot after the first char, so it's treated as a file
-    const result = extractGrantDirectory("/project/.git");
-    expect(result).toBe("/project");
+  it("returns as-is for hidden directory (.git) — heuristic", async () => {
+    // .git doesn't exist at this path → heuristic: single dot-prefix, no further dots → directory
+    const result = await extractGrantDirectory("/project/.git");
+    expect(result).toBe("/project/.git");
   });
 
-  it("returns parent for deeply nested file", () => {
-    const result = extractGrantDirectory("/a/b/c/d/file.json");
+  it("returns as-is for hidden directory (.ssh) — heuristic", async () => {
+    const result = await extractGrantDirectory("/project/.ssh");
+    expect(result).toBe("/project/.ssh");
+  });
+
+  it("returns parent for deeply nested file", async () => {
+    const result = await extractGrantDirectory("/a/b/c/d/file.json");
     expect(result).toBe("/a/b/c/d");
   });
 
-  it("handles Windows-style backslashes (normalizes to forward slashes)", () => {
-    const result = extractGrantDirectory("C:\\project\\src\\file.ts");
-    // On non-Windows, resolve() treats C:\project as relative to cwd,
-    // so just verify the function doesn't crash and the backslash
-    // normalization in extractGrantDirectory works
+  it("handles Windows-style backslashes (normalizes to forward slashes)", async () => {
+    const result = await extractGrantDirectory("C:\\project\\src\\file.ts");
     expect(result).not.toContain("\\");
+  });
+
+  it("uses stat for real files — returns parent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grant-test-"));
+    const filePath = join(dir, "real-file.ts");
+    await writeFile(filePath, "test");
+    const result = await extractGrantDirectory(filePath);
+    expect(result).toBe(dir);
+    await rm(dir, { recursive: true });
+  });
+
+  it("uses stat for real directories — returns as-is", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grant-test-"));
+    const subDir = join(dir, ".git");
+    await mkdir(subDir);
+    const result = await extractGrantDirectory(subDir);
+    expect(result).toBe(subDir);
+    await rm(dir, { recursive: true });
   });
 });

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  expandHomePath,
+  extractGrantDirectory,
+  isWithinLexicalBoundary,
+  resolveFromCwd,
+} from "./path";
+
+describe("expandHomePath", () => {
+  it("expands bare ~ to homedir", () => {
+    expect(expandHomePath("~")).toMatch(/^\/Users\/|^\/home\//);
+  });
+
+  it("expands ~/foo to homedir/foo", () => {
+    const result = expandHomePath("~/foo");
+    expect(result).toMatch(/\/foo$/);
+    expect(result.startsWith("~")).toBe(false);
+  });
+
+  it("leaves absolute paths unchanged", () => {
+    expect(expandHomePath("/etc/hosts")).toBe("/etc/hosts");
+  });
+
+  it("leaves relative paths unchanged", () => {
+    expect(expandHomePath("foo/bar")).toBe("foo/bar");
+  });
+
+  it("leaves ~ in the middle unchanged", () => {
+    expect(expandHomePath("/foo~/bar")).toBe("/foo~/bar");
+  });
+});
+
+describe("resolveFromCwd", () => {
+  it("resolves relative path against cwd", () => {
+    expect(resolveFromCwd("src/index.ts", "/project")).toBe(
+      "/project/src/index.ts",
+    );
+  });
+
+  it("resolves absolute path as-is", () => {
+    expect(resolveFromCwd("/etc/hosts", "/project")).toBe("/etc/hosts");
+  });
+
+  it("expands ~ then resolves against cwd", () => {
+    const result = resolveFromCwd("~/code", "/project");
+    expect(result).not.toContain("~");
+    expect(result).toMatch(/\/code$/);
+  });
+
+  it("resolves .. correctly", () => {
+    expect(resolveFromCwd("../outside/file.txt", "/project/src")).toBe(
+      "/project/outside/file.txt",
+    );
+  });
+});
+
+describe("isWithinLexicalBoundary", () => {
+  it("returns true for exact match", () => {
+    expect(isWithinLexicalBoundary("/project", "/project")).toBe(true);
+  });
+
+  it("returns true for descendant", () => {
+    expect(isWithinLexicalBoundary("/project/src/index.ts", "/project")).toBe(
+      true,
+    );
+  });
+
+  it("returns true for nested descendant", () => {
+    expect(isWithinLexicalBoundary("/project/a/b/c/file.ts", "/project")).toBe(
+      true,
+    );
+  });
+
+  it("returns false for sibling", () => {
+    expect(isWithinLexicalBoundary("/other", "/project")).toBe(false);
+  });
+
+  it("returns false for parent", () => {
+    expect(isWithinLexicalBoundary("/", "/project")).toBe(false);
+  });
+
+  it("returns false for escape via ..", () => {
+    // resolve("/project", "../../x") => resolves to something outside
+    expect(isWithinLexicalBoundary("/other-project/file.ts", "/project")).toBe(
+      false,
+    );
+  });
+
+  it("handles foo/../bar (still inside)", () => {
+    // resolve("/project/outside/../src/file.ts") => "/project/src/file.ts"
+    const target = "/project/outside/../src/file.ts";
+    expect(isWithinLexicalBoundary(target, "/project")).toBe(true);
+  });
+
+  it("handles ../../x (outside)", () => {
+    const target = "/project/../../etc/hosts";
+    expect(isWithinLexicalBoundary(target, "/project")).toBe(false);
+  });
+
+  it("returns true for cwd with trailing slash", () => {
+    expect(isWithinLexicalBoundary("/project/file.ts", "/project/")).toBe(true);
+  });
+
+  it("returns false for prefix trick (no slash boundary)", () => {
+    // /project2 should NOT be inside /project
+    expect(isWithinLexicalBoundary("/project2/file.ts", "/project")).toBe(
+      false,
+    );
+  });
+});
+
+describe("extractGrantDirectory", () => {
+  it("returns parent for file with extension", () => {
+    const result = extractGrantDirectory("/project/src/index.ts");
+    expect(result).toBe("/project/src");
+  });
+
+  it("returns parent for dotfile with no further dots (.env)", () => {
+    const result = extractGrantDirectory("/project/.env");
+    expect(result).toBe("/project");
+  });
+
+  it("returns parent for dotfile with dots (.env.local)", () => {
+    const result = extractGrantDirectory("/project/.env.local");
+    expect(result).toBe("/project");
+  });
+
+  it("returns as-is for directory (no dot in last segment)", () => {
+    const result = extractGrantDirectory("/project/src");
+    expect(result).toBe("/project/src");
+  });
+
+  it("returns parent for hidden directory with dot (.git)", () => {
+    // ".git" has no dot after the first char, so it's treated as a file
+    const result = extractGrantDirectory("/project/.git");
+    expect(result).toBe("/project");
+  });
+
+  it("returns parent for deeply nested file", () => {
+    const result = extractGrantDirectory("/a/b/c/d/file.json");
+    expect(result).toBe("/a/b/c/d");
+  });
+
+  it("handles Windows-style backslashes", () => {
+    const result = extractGrantDirectory("C:\\project\\src\\file.ts");
+    // After normalize: "C:/project/src/file.ts" -> parent "C:/project/src"
+    // resolve() on macOS will resolve relative to cwd, but the split on "/" works
+    expect(result).toContain("src");
+  });
+});

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -31,6 +31,12 @@ describe("expandHomePath", () => {
   it("leaves ~ in the middle unchanged", () => {
     expect(expandHomePath("/foo~/bar")).toBe("/foo~/bar");
   });
+
+  it("expands ~\\foo to homedir/foo (Windows backslash)", () => {
+    const result = expandHomePath("~\\foo");
+    expect(result).not.toContain("~");
+    expect(result).toMatch(/foo$/);
+  });
 });
 
 describe("resolveFromCwd", () => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -11,7 +11,7 @@ export function expandHomePath(input: string): string {
     return homedir();
   }
 
-  if (input.startsWith("~/")) {
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
     return join(homedir(), input.slice(2));
   }
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,3 +1,4 @@
+import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
@@ -40,25 +41,33 @@ export function isWithinLexicalBoundary(
 
 /**
  * Extract the directory portion for a grant.
- * If the path looks like a file (has a dot that indicates an extension),
- * return its parent dir. Otherwise return the path as-is (assume directory).
- *
- * Handles dotfiles like .env correctly by treating them as files.
- * A segment is considered a file if it contains a dot after the first
- * character (e.g. "file.ts", ".env.local") or is a dotfile with no
- * further dots (e.g. ".env", ".gitignore").
+ * If the path exists on disk and is a directory, return it as-is.
+ * If it exists and is a file, return its parent dir.
+ * If it doesn't exist, fall back to a heuristic: paths with an extension
+ * dot (that is not a leading dot) are treated as files; everything else
+ * is assumed to be a directory.
  */
-export function extractGrantDirectory(absPath: string): string {
+export async function extractGrantDirectory(absPath: string): Promise<string> {
+  // Check the filesystem first — the ground truth
+  try {
+    const s = await stat(absPath);
+    return s.isDirectory() ? absPath : resolve(absPath, "..");
+  } catch {
+    // Path doesn't exist — fall back to heuristic
+  }
+
   const normalized = absPath.replace(/\\/g, "/");
   const lastSegment = normalized.split("/").pop() ?? "";
-  // Dotfile with no further dots (e.g. ".env") → file
-  if (lastSegment.startsWith(".") && !lastSegment.slice(1).includes(".")) {
+
+  // Has an extension dot that is not the leading dot: "file.ts", ".env.local"
+  // but NOT ".git", ".ssh", ".vscode" (single dot-prefix, no further dots)
+  const afterLeadingDot = lastSegment.startsWith(".")
+    ? lastSegment.slice(1)
+    : lastSegment;
+  if (afterLeadingDot.includes(".")) {
     return resolve(absPath, "..");
   }
-  // Has a dot anywhere → likely a file with extension (e.g. "file.ts", ".env.local")
-  if (lastSegment.includes(".")) {
-    return resolve(absPath, "..");
-  }
-  // No dot → assume directory
+
+  // No extension dot (or single dot-prefix with no further dots): assume directory
   return absPath;
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 /**
  * Expand a leading tilde to the current user's home directory.
@@ -15,4 +15,50 @@ export function expandHomePath(input: string): string {
   }
 
   return input;
+}
+
+/**
+ * Resolve a path relative to cwd, expanding ~ first.
+ */
+export function resolveFromCwd(input: string, cwd: string): string {
+  return resolve(cwd, expandHomePath(input));
+}
+
+/**
+ * Check if targetPath is inside rootPath (lexical check only, no realpath).
+ * Returns true if targetPath equals rootPath or is a descendant.
+ */
+export function isWithinLexicalBoundary(
+  targetPath: string,
+  rootPath: string,
+): boolean {
+  const absTarget = resolve(targetPath);
+  const absRoot = resolve(rootPath);
+  const rel = relative(absRoot, absTarget);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * Extract the directory portion for a grant.
+ * If the path looks like a file (has a dot that indicates an extension),
+ * return its parent dir. Otherwise return the path as-is (assume directory).
+ *
+ * Handles dotfiles like .env correctly by treating them as files.
+ * A segment is considered a file if it contains a dot after the first
+ * character (e.g. "file.ts", ".env.local") or is a dotfile with no
+ * further dots (e.g. ".env", ".gitignore").
+ */
+export function extractGrantDirectory(absPath: string): string {
+  const normalized = absPath.replace(/\\/g, "/");
+  const lastSegment = normalized.split("/").pop() ?? "";
+  // Dotfile with no further dots (e.g. ".env") → file
+  if (lastSegment.startsWith(".") && !lastSegment.slice(1).includes(".")) {
+    return resolve(absPath, "..");
+  }
+  // Has a dot anywhere → likely a file with extension (e.g. "file.ts", ".env.local")
+  if (lastSegment.includes(".")) {
+    return resolve(absPath, "..");
+  }
+  // No dot → assume directory
+  return absPath;
 }


### PR DESCRIPTION
**PR opened by pi (synthetic/hf:zai-org/GLM-5.1)**

## Summary

Add a `directoryAccess` feature that restricts file access to the current working directory and approved additional directories.

### Modes
- **block** — always deny access outside the working directory
- **ask** — prompt with options: allow once, allow for session, allow for project, or deny
- **allow** — no directory restrictions (feature disabled)

### Config
```jsonc
{
  "features": { "directoryAccess": true },
  "directoryAccess": {
    "mode": "ask",
    "additionalDirs": ["~/code/shared-libs"]
  }
}
```

### Key changes
- New `directoryAccess` feature with block/ask/allow modes
- Boundary check runs **before** policy checks (file inside cwd still blocked by policies)
- `additionalDirs` merged across scopes (global + local + memory), supports `~` expansion
- Session grants saved to memory scope, project grants saved to local scope
- Ask mode degrades to block when no UI available (`--print` mode)
- Refactored bash path extraction: decoupled from policy matching, added `maybePathLike` filter in AST path
- Fixed glob expansion to use `ctx.cwd`
- Re-read boundary config on each `tool_call` so settings changes take effect immediately
- Migration for existing users: feature disabled by default to preserve existing behavior
- Onboarding step for directory access mode selection
- Settings UI for mode, additional dirs
- 56 unit tests (path utils, migration, policies)

### Bug fix (separate commit)
- Re-read `allowedPatterns`, `autoDenyPatterns`, `requireConfirmation`, `explainCommands` from `configLoader.getConfig()` on each `tool_call` in the permission gate hook. Previously cached in closure at setup time — settings changes had no effect until Pi restart.