### PR TITLE
feat: add path access feature

### DIFF
--- a/.changeset/path-access-feature.md
+++ b/.changeset/path-access-feature.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add path access feature: restrict tool access to current working directory with allow/ask/block modes. Grants can be file-level (exact match) or directory-level (trailing slash convention). Session grants persist in memory, project grants persist in local config.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ pi install git:github.com/aliou/pi-guardrails
 
 - **policies**: named file-protection rules with per-rule protection levels.
 - **permission-gate**: detects dangerous bash commands and asks for confirmation.
+- **path-access**: restricts tool access to the current working directory with allow/ask/block modes.
 - **optional command explainer**: can call a small LLM to explain a dangerous command inline in the confirmation dialog.
 
 ## Config locations
@@ -48,7 +49,12 @@ Use `/guardrails:settings` to edit config interactively.
   "enabled": true,
   "features": {
     "policies": true,
-    "permissionGate": true
+    "permissionGate": true,
+    "pathAccess": false
+  },
+  "pathAccess": {
+    "mode": "ask",
+    "allowedPaths": []
   },
   "policies": {
     "rules": [
@@ -121,6 +127,31 @@ Use:
 
 This starts a subagent that helps build and save one policy rule.
 
+## Path access
+
+Restrict tool access to the current working directory. When enabled, any tool call targeting a path outside `cwd` is checked against the configured mode:
+
+- **allow**: no restrictions
+- **ask**: prompt with options to grant access (file or directory, for session or always)
+- **block**: deny all outside access
+
+```jsonc
+{
+  "features": { "pathAccess": true },
+  "pathAccess": {
+    "mode": "ask",
+    "allowedPaths": ["~/code/shared-libs/", "~/.config/myapp"]
+  }
+}
+```
+
+Grants are stored in project config (always) or session memory (session). The `allowedPaths` array is merged across all config scopes.
+
+Limitations:
+- Symlinks are not resolved (lexical path comparison only).
+- Bash path extraction is best-effort (AST-based heuristics).
+- In non-interactive mode, `ask` mode degrades to `block`.
+
 ## Permission gate
 
 Detects dangerous bash commands and prompts user confirmation.
@@ -169,7 +200,7 @@ Guardrails emits events for other extensions:
 
 ```ts
 interface GuardrailsBlockedEvent {
-  feature: "policies" | "permissionGate";
+  feature: "policies" | "permissionGate" | "pathAccess";
   toolName: string;
   input: Record<string, unknown>;
   reason: string;

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -101,6 +101,31 @@ Blocks access to GPG/GnuPG private keys, keyrings, and configuration. Disabled b
 
 ---
 
+## Path Access
+
+| Setting | Default |
+|---|---|
+| `features.pathAccess` | `false` |
+| `pathAccess.mode` | `"ask"` |
+| `pathAccess.allowedPaths` | `[]` |
+
+Modes:
+- `allow` — no path restrictions
+- `ask` — prompt when accessing paths outside working directory
+- `block` — deny all access outside working directory
+
+Allowed paths use trailing-slash convention:
+- `/path/to/file` — exact file match
+- `/path/to/dir/` — directory and all descendants
+- Supports `~/` for home directory
+
+Limitations:
+- Bash path extraction is best-effort (AST-based heuristics). Tokens like `application/json` may trigger false-positive prompts.
+- Symlinks are not resolved. Lexical path comparison only.
+- In non-interactive mode (--print), `ask` mode degrades to `block`.
+
+---
+
 ## Default Permission Gate Patterns
 
 These commands are detected using AST-based structural matching for accuracy.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "@sinclair/typebox": "^0.34.48",
     "@types/node": "^25.0.10",
     "husky": "^9.1.7",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
   },
   "pnpm": {
     "overrides": {
@@ -59,6 +60,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "biome check",
     "format": "biome check --write",
     "check:lockfile": "pnpm install --frozen-lockfile --ignore-scripts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.2.3)(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2))
 
 packages:
 
@@ -345,6 +348,15 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@google/genai@1.41.0':
     resolution: {integrity: sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==}
     engines: {node: '>=20.0.0'}
@@ -366,6 +378,9 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -461,6 +476,12 @@ packages:
   '@mistralai/mistralai@1.14.1':
     resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -472,6 +493,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -506,6 +530,98 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
@@ -705,6 +821,9 @@ packages:
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -714,6 +833,18 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
@@ -726,6 +857,35 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -775,6 +935,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -821,6 +985,10 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -851,6 +1019,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -880,6 +1051,10 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
@@ -907,6 +1082,9 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -925,9 +1103,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -960,6 +1145,15 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -991,6 +1185,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
@@ -1159,6 +1358,76 @@ packages:
   koffi@2.15.2:
     resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1179,6 +1448,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -1223,6 +1495,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -1239,6 +1516,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1328,6 +1608,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -1338,9 +1621,17 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -1398,6 +1689,11 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1419,6 +1715,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1443,6 +1742,10 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -1453,8 +1756,14 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1498,6 +1807,21 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1532,6 +1856,90 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -1539,6 +1947,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -2277,6 +2690,22 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@google/genai@1.41.0':
     dependencies:
       google-auth-library: 10.5.0
@@ -2303,6 +2732,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -2456,6 +2887,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2467,6 +2905,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxc-project/types@0.124.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2493,6 +2933,57 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
@@ -2802,6 +3293,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -2812,6 +3305,20 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/mime-types@2.1.4': {}
 
@@ -2825,6 +3332,47 @@ snapshots:
     dependencies:
       '@types/node': 25.2.3
     optional: true
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.2.3)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   agent-base@7.1.4: {}
 
@@ -2860,6 +3408,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -2897,6 +3447,8 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2929,6 +3481,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2950,6 +3504,8 @@ snapshots:
       esprima: 4.0.1
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
 
@@ -2976,6 +3532,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  es-module-lexer@2.0.0: {}
+
   escalade@3.2.0: {}
 
   escodegen@2.1.0:
@@ -2990,7 +3548,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -3029,6 +3593,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -3073,6 +3641,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.3:
+    optional: true
 
   gaxios@7.1.3:
     dependencies:
@@ -3260,6 +3831,55 @@ snapshots:
   koffi@2.15.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -3273,6 +3893,10 @@ snapshots:
   lru-cache@11.2.6: {}
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
 
@@ -3309,6 +3933,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   netmask@2.0.2: {}
 
   node-domexception@1.0.0: {}
@@ -3320,6 +3946,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -3402,13 +4030,23 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.4: {}
+
   pify@4.0.1: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier@2.8.8: {}
 
@@ -3478,6 +4116,27 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3493,6 +4152,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -3515,6 +4176,8 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1:
     optional: true
 
@@ -3525,7 +4188,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3569,6 +4236,17 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -3593,11 +4271,55 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      yaml: 2.8.2
+
+  vitest@4.1.4(@types/node@25.2.3)(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.2.3)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.2.3)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/commands/onboarding-command.ts
+++ b/src/commands/onboarding-command.ts
@@ -10,12 +10,25 @@ import {
 function mergeOnboarding(
   base: GuardrailsConfig | null,
   applyBuiltinDefaults: boolean,
+  pathAccessEnabled?: boolean | null,
 ): GuardrailsConfig {
   const next = structuredClone(base ?? {});
-  const onboarded = buildOnboardedConfig(applyBuiltinDefaults);
+  const onboarded = buildOnboardedConfig(
+    applyBuiltinDefaults,
+    pathAccessEnabled,
+  );
   next.applyBuiltinDefaults = onboarded.applyBuiltinDefaults;
   next.version = onboarded.version;
   next.onboarding = onboarded.onboarding;
+  if (onboarded.features?.pathAccess !== undefined) {
+    next.features = {
+      ...next.features,
+      pathAccess: onboarded.features.pathAccess,
+    };
+  }
+  if (onboarded.pathAccess) {
+    next.pathAccess = onboarded.pathAccess;
+  }
   return next;
 }
 
@@ -48,7 +61,11 @@ export function registerGuardrailsOnboardingCommand(
         return;
       }
 
-      const merged = mergeOnboarding(globalConfig, result.applyBuiltinDefaults);
+      const merged = mergeOnboarding(
+        globalConfig,
+        result.applyBuiltinDefaults,
+        result.pathAccessEnabled,
+      );
       await configLoader.save("global", merged);
       await configLoader.load();
 

--- a/src/commands/onboarding.ts
+++ b/src/commands/onboarding.ts
@@ -11,11 +11,13 @@ import { CURRENT_VERSION } from "../utils/migration";
 
 interface OnboardingState {
   applyBuiltinDefaults: boolean | null;
+  pathAccessEnabled: boolean | null;
 }
 
 export interface OnboardingResult {
   completed: boolean;
   applyBuiltinDefaults: boolean | null;
+  pathAccessEnabled: boolean | null;
 }
 
 class IntroStep implements Component {
@@ -129,6 +131,88 @@ class DefaultsChoiceStep implements Component {
   }
 }
 
+class PathAccessStep implements Component {
+  private selectedIndex = 0;
+  private readonly settingsTheme: SettingsTheme;
+
+  constructor(
+    private readonly theme: Theme,
+    private readonly state: OnboardingState,
+    private readonly onSelect: () => void,
+  ) {
+    this.settingsTheme = getSettingsTheme(theme);
+  }
+
+  invalidate() {}
+
+  render(width: number): string[] {
+    const options = ["Ask before accessing outside files", "No restrictions"];
+    const explanations = [
+      [
+        "When enabled, guardrails will prompt you before the agent accesses files outside the current working directory.",
+        "",
+        "- You can grant access per-file or per-directory",
+        "- Grants can be session-only or permanent",
+        "- In non-interactive mode, outside access is blocked",
+      ].join("\n"),
+      [
+        "The agent can access any path on your system without prompting.",
+        "",
+        "- You can enable path access later in `/guardrails:settings`",
+      ].join("\n"),
+    ];
+
+    const lines: string[] = [
+      "  Restrict access to your project directory?",
+      "",
+    ];
+
+    for (let i = 0; i < options.length; i++) {
+      const option = options[i];
+      if (!option) continue;
+      const selected = i === this.selectedIndex;
+      const prefix = selected ? this.settingsTheme.cursor : "  ";
+      const label = this.settingsTheme.value(` ${option}`, selected);
+      lines.push(`${prefix}${label}`);
+    }
+
+    lines.push("");
+
+    const explanationBox = new Box(1, 0, (s: string) => s);
+    explanationBox.addChild(
+      new Markdown(
+        explanations[this.selectedIndex] ?? "",
+        0,
+        0,
+        getMarkdownTheme(),
+        {
+          color: (s: string) => this.theme.fg("text", s),
+        },
+      ),
+    );
+
+    lines.push(...explanationBox.render(Math.max(1, width)));
+
+    return lines;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.up) || data === "k") {
+      this.selectedIndex = this.selectedIndex === 0 ? 1 : 0;
+      return;
+    }
+    if (matchesKey(data, Key.down) || data === "j") {
+      this.selectedIndex = this.selectedIndex === 1 ? 0 : 1;
+      return;
+    }
+
+    if (matchesKey(data, Key.enter)) {
+      this.state.pathAccessEnabled = this.selectedIndex === 0;
+      this.onSelect();
+    }
+  }
+}
+
 class FinishStep implements Component {
   private readonly recapMarkdown = new Markdown("", 2, 0, getMarkdownTheme());
 
@@ -142,7 +226,7 @@ class FinishStep implements Component {
   }
 
   render(width: number): string[] {
-    const content =
+    const defaultsPart =
       this.state.applyBuiltinDefaults === true
         ? [
             "You selected **Recommended defaults**.",
@@ -159,6 +243,12 @@ class FinishStep implements Component {
             "",
             "You can configure policies later with `/guardrails:settings`.",
           ].join("\n");
+
+    const pathAccessPart = this.state.pathAccessEnabled
+      ? "\n\n**Path access**: enabled (ask mode). The agent will prompt before accessing files outside the working directory."
+      : "\n\n**Path access**: disabled. No path restrictions.";
+
+    const content = defaultsPart + pathAccessPart;
 
     this.recapMarkdown.setText(content);
     return [...this.recapMarkdown.render(Math.max(1, width)), ""];
@@ -177,6 +267,7 @@ export function createOnboardingWizard(
 ): Component {
   const state: OnboardingState = {
     applyBuiltinDefaults: null,
+    pathAccessEnabled: null,
   };
 
   let markWelcomeComplete: (() => void) | null = null;
@@ -211,6 +302,14 @@ export function createOnboardingWizard(
           }),
       },
       {
+        label: "Path access",
+        build: (ctx) =>
+          new PathAccessStep(theme, state, () => {
+            ctx.markComplete();
+            ctx.goNext();
+          }),
+      },
+      {
         label: "Recap",
         build: (ctx) =>
           new FinishStep(state, () => {
@@ -219,21 +318,32 @@ export function createOnboardingWizard(
             finalize({
               completed: true,
               applyBuiltinDefaults: state.applyBuiltinDefaults,
+              pathAccessEnabled: state.pathAccessEnabled,
             });
           }),
       },
     ],
     onComplete: () => {
       if (state.applyBuiltinDefaults === null) {
-        finalize({ completed: false, applyBuiltinDefaults: null });
+        finalize({
+          completed: false,
+          applyBuiltinDefaults: null,
+          pathAccessEnabled: null,
+        });
         return;
       }
       finalize({
         completed: true,
         applyBuiltinDefaults: state.applyBuiltinDefaults,
+        pathAccessEnabled: state.pathAccessEnabled,
       });
     },
-    onCancel: () => finalize({ completed: false, applyBuiltinDefaults: null }),
+    onCancel: () =>
+      finalize({
+        completed: false,
+        applyBuiltinDefaults: null,
+        pathAccessEnabled: null,
+      }),
     hintSuffix: "Enter select/continue",
     minContentHeight: 12,
   });
@@ -256,8 +366,9 @@ export function createOnboardingWizard(
 
 export function buildOnboardedConfig(
   applyBuiltinDefaults: boolean,
+  pathAccessEnabled?: boolean | null,
 ): GuardrailsConfig {
-  return {
+  const config: GuardrailsConfig = {
     version: CURRENT_VERSION,
     applyBuiltinDefaults,
     onboarding: {
@@ -266,6 +377,11 @@ export function buildOnboardedConfig(
       version: CURRENT_VERSION,
     },
   };
+  if (pathAccessEnabled) {
+    config.features = { ...config.features, pathAccess: true };
+    config.pathAccess = { mode: "ask" };
+  }
+  return config;
 }
 
 export function isOnboardingPending(config: GuardrailsConfig | null): boolean {

--- a/src/commands/settings-command.ts
+++ b/src/commands/settings-command.ts
@@ -40,6 +40,10 @@ const FEATURE_UI: Record<FeatureKey, { label: string; description: string }> = {
     description:
       "Prompt for confirmation on dangerous commands (rm -rf, sudo, etc.)",
   },
+  pathAccess: {
+    label: "Path access",
+    description: "Restrict tool access to the current working directory",
+  },
 };
 
 const POLICY_EXAMPLES: Array<{
@@ -1209,6 +1213,31 @@ export function registerGuardrailsSettings(pi: ExtensionAPI): void {
         {
           label: `Policies (${policyRules.length})`,
           items: policyItems,
+        },
+        {
+          label: "Path Access",
+          items: [
+            {
+              id: "pathAccess.mode",
+              label: "Mode",
+              description:
+                "allow: no restrictions, ask: prompt for outside paths, block: deny all outside paths",
+              currentValue: scopedConfig.pathAccess?.mode ?? "(inherited)",
+              values: ["allow", "ask", "block"],
+            },
+            {
+              id: "pathAccess.allowedPaths",
+              label: "Allowed paths",
+              description:
+                "Paths always allowed (trailing / for directories). Supports ~/",
+              currentValue: count("pathAccess.allowedPaths"),
+              submenu: patternConfigSubmenu(
+                "pathAccess.allowedPaths",
+                "Allowed Paths",
+                "file",
+              ),
+            },
+          ],
         },
         {
           label: "Permission Gate",

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,13 @@ export interface PolicyRule {
   enabled?: boolean;
 }
 
+export type PathAccessMode = "allow" | "ask" | "block";
+
+export interface PathAccessConfig {
+  mode?: PathAccessMode;
+  allowedPaths?: string[];
+}
+
 export interface GuardrailsConfig {
   version?: string;
   enabled?: boolean;
@@ -66,12 +73,14 @@ export interface GuardrailsConfig {
   features?: {
     policies?: boolean;
     permissionGate?: boolean;
+    pathAccess?: boolean;
     // Deprecated. Kept only for migration.
     protectEnvFiles?: boolean;
   };
   policies?: {
     rules?: PolicyRule[];
   };
+  pathAccess?: PathAccessConfig;
   // Deprecated. Kept only for migration.
   envFiles?: {
     protectedPatterns?: PatternConfig[];
@@ -101,9 +110,14 @@ export interface ResolvedConfig {
   features: {
     policies: boolean;
     permissionGate: boolean;
+    pathAccess: boolean;
   };
   policies: {
     rules: PolicyRule[];
+  };
+  pathAccess: {
+    mode: PathAccessMode;
+    allowedPaths: string[];
   };
   permissionGate: {
     patterns: DangerousPattern[];
@@ -199,6 +213,11 @@ const DEFAULT_CONFIG: ResolvedConfig = {
   features: {
     policies: true,
     permissionGate: true,
+    pathAccess: false,
+  },
+  pathAccess: {
+    mode: "ask",
+    allowedPaths: [],
   },
   policies: {
     rules: [
@@ -337,6 +356,19 @@ export const configLoader = new ConfigLoader<GuardrailsConfig, ResolvedConfig>(
         resolved.permissionGate.patterns = customPatterns;
         resolved.permissionGate.useBuiltinMatchers = false;
       }
+      // Merge allowedPaths across scopes (additive)
+      const mergedPaths = new Set<string>();
+      for (const paths of [
+        global?.pathAccess?.allowedPaths,
+        local?.pathAccess?.allowedPaths,
+        memory?.pathAccess?.allowedPaths,
+      ]) {
+        if (paths) {
+          for (const p of paths) mergedPaths.add(p);
+        }
+      }
+      resolved.pathAccess.allowedPaths = [...mergedPaths];
+
       return resolved;
     },
   },

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,9 +1,11 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { ResolvedConfig } from "../config";
+import { setupPathAccessHook } from "./path-access";
 import { setupPermissionGateHook } from "./permission-gate";
 import { setupPoliciesHook } from "./policies";
 
 export function setupGuardrailsHooks(pi: ExtensionAPI, config: ResolvedConfig) {
-  setupPoliciesHook(pi, config);
-  setupPermissionGateHook(pi, config);
+  setupPathAccessHook(pi); // boundary check — runs first
+  setupPoliciesHook(pi, config); // policy rules — runs second
+  setupPermissionGateHook(pi, config); // dangerous commands — runs third
 }

--- a/src/hooks/path-access.ts
+++ b/src/hooks/path-access.ts
@@ -1,0 +1,396 @@
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+  Container,
+  Key,
+  matchesKey,
+  Spacer,
+  Text,
+  visibleWidth,
+} from "@mariozechner/pi-tui";
+import { configLoader } from "../config";
+import { extractBashPathCandidates } from "../utils/bash-paths";
+import { emitBlocked } from "../utils/events";
+import {
+  normalizeForDisplay,
+  resolveFromCwd,
+  toStorageForm,
+} from "../utils/path";
+import { checkPathAccess, type PathAccessState } from "../utils/path-access";
+
+// Grant result type from the UI prompt
+type PromptResult =
+  | "allow-file-once"
+  | "allow-dir-once"
+  | "allow-file-session"
+  | "allow-dir-session"
+  | "allow-file-always"
+  | "allow-dir-always"
+  | "deny";
+
+// Pending grant to be persisted after all targets pass
+interface PendingGrant {
+  storagePath: string; // in storage form (~/..., trailing / for dirs)
+  scope: "memory" | "local";
+  absolutePath: string; // for in-loop matching
+}
+
+/**
+ * Resolve allowedPaths from config to absolute paths, preserving trailing-slash convention.
+ */
+function resolveAllowedPaths(allowedPaths: string[], cwd: string): string[] {
+  return allowedPaths.map((p) => {
+    const isDir = p.endsWith("/");
+    const resolved = resolveFromCwd(isDir ? p.slice(0, -1) : p, cwd);
+    return isDir ? `${resolved}/` : resolved;
+  });
+}
+
+/**
+ * Check if a grant path would be too broad (/ or home directory).
+ */
+function isGrantTooBroad(absPath: string): boolean {
+  const home = homedir();
+  const normalized = absPath.replace(/[\\/]+$/, "");
+  return normalized === "/" || normalized === home;
+}
+
+/**
+ * Collapse home directory to ~ for display.
+ */
+function displayCwd(cwd: string): string {
+  const home = homedir();
+  if (cwd === home) return "~";
+  if (cwd.startsWith(`${home}/`) || cwd.startsWith(`${home}\\`)) {
+    return `~${cwd.slice(home.length)}`;
+  }
+  return cwd;
+}
+
+interface PromptOption {
+  label: string;
+  result: PromptResult;
+}
+
+const FILE_OPTIONS: PromptOption[] = [
+  { label: "Allow once", result: "allow-file-once" },
+  { label: "Allow file this session", result: "allow-file-session" },
+  { label: "Allow file always", result: "allow-file-always" },
+  { label: "Allow directory this session", result: "allow-dir-session" },
+  { label: "Allow directory always", result: "allow-dir-always" },
+  { label: "Deny", result: "deny" },
+];
+
+const DIR_OPTIONS: PromptOption[] = [
+  { label: "Allow once", result: "allow-dir-once" },
+  { label: "Allow directory this session", result: "allow-dir-session" },
+  { label: "Allow directory always", result: "allow-dir-always" },
+  { label: "Deny", result: "deny" },
+];
+
+/**
+ * Build the confirmation UI component.
+ * For directory-oriented tools (ls, find): only directory grant options.
+ * For file tools and bash: both file and directory options.
+ * Options rendered as highlighted tabs (selected = accent bg, unselected = dim),
+ * navigable with ←/→/Tab/Shift+Tab.
+ */
+function createPromptComponent(
+  toolName: string,
+  displayPath: string,
+  displayDir: string,
+  cwd: string,
+  showFileOptions: boolean,
+) {
+  return (
+    tui: { terminal: { columns: number }; requestRender(): void },
+    theme: {
+      fg(color: string, text: string): string;
+      bg(color: string, text: string): string;
+      bold(text: string): string;
+    },
+    _kb: unknown,
+    done: (result: PromptResult) => void,
+  ) => {
+    const options = showFileOptions ? FILE_OPTIONS : DIR_OPTIONS;
+    let selectedIndex = 0;
+
+    const container = new Container();
+    const border = (s: string) => theme.fg("warning", s);
+    const cwdDisplay = displayCwd(cwd);
+
+    container.addChild(
+      new Text(
+        theme.fg("warning", theme.bold("Outside Workspace Access")),
+        1,
+        0,
+      ),
+    );
+    container.addChild(new Spacer(1));
+    container.addChild(
+      new Text(
+        theme.fg(
+          "text",
+          `\`${toolName}\` targets a path outside the working directory.`,
+        ),
+        1,
+        0,
+      ),
+    );
+    container.addChild(new Spacer(1));
+    container.addChild(
+      new Text(theme.fg("dim", `  Cwd:  ${cwdDisplay}`), 1, 0),
+    );
+    container.addChild(
+      new Text(theme.fg("dim", `  Path: ${displayPath}`), 1, 0),
+    );
+    container.addChild(
+      new Text(theme.fg("dim", `  Dir:  ${displayDir}`), 1, 0),
+    );
+    container.addChild(new Spacer(1));
+
+    // Dynamically rendered option lines
+    const optionLines: Text[] = options.map(() => new Text("", 1, 0));
+    for (const line of optionLines) {
+      container.addChild(line);
+    }
+
+    container.addChild(new Spacer(1));
+    container.addChild(
+      new Text(
+        theme.fg("dim", "↑/↓/Tab select · Enter select · Esc deny"),
+        1,
+        0,
+      ),
+    );
+
+    const renderOptions = () => {
+      for (let i = 0; i < options.length; i++) {
+        const label = options[i].label;
+        if (i === selectedIndex) {
+          optionLines[i].setText(
+            theme.bg("selectedBg", theme.fg("accent", ` ${label} `)),
+          );
+        } else {
+          optionLines[i].setText(theme.fg("dim", ` ${label} `));
+        }
+      }
+    };
+
+    renderOptions();
+
+    const moveSelection = (direction: number) => {
+      selectedIndex =
+        (selectedIndex + direction + options.length) % options.length;
+      renderOptions();
+      tui.requestRender();
+    };
+
+    return {
+      render: (width: number) => {
+        const innerWidth = Math.max(1, width - 2);
+        const contentWidth = Math.max(1, width - 4);
+        const raw = container.render(contentWidth);
+        const top = border(`╭${"─".repeat(innerWidth)}╮`);
+        const bottom = border(`╰${"─".repeat(innerWidth)}╯`);
+        const left = border("│");
+        const right = border("│");
+        const lines = raw.map((line) => {
+          const visible = visibleWidth(line);
+          const pad = Math.max(0, contentWidth - visible);
+          return `${left} ${line}${" ".repeat(pad)} ${right}`;
+        });
+        return [top, ...lines, bottom];
+      },
+      invalidate: () => container.invalidate(),
+      handleInput: (data: string) => {
+        if (
+          matchesKey(data, Key.up) ||
+          data === "k" ||
+          matchesKey(data, Key.shift("tab"))
+        ) {
+          moveSelection(-1);
+          return;
+        }
+        if (
+          matchesKey(data, Key.down) ||
+          data === "j" ||
+          matchesKey(data, Key.tab)
+        ) {
+          moveSelection(1);
+          return;
+        }
+        if (matchesKey(data, Key.enter)) {
+          done(options[selectedIndex].result);
+          return;
+        }
+        if (matchesKey(data, Key.escape)) {
+          done("deny");
+        }
+      },
+    };
+  };
+}
+
+/**
+ * Persist a grant to the given config scope.
+ * Re-reads raw config before saving to avoid clobbering concurrent changes.
+ */
+async function persistGrant(
+  storagePath: string,
+  scope: "memory" | "local",
+): Promise<void> {
+  const raw = (configLoader.getRawConfig(scope) ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const pa = (raw.pathAccess ?? {}) as Record<string, unknown>;
+  const existing = Array.isArray(pa.allowedPaths)
+    ? (pa.allowedPaths as string[])
+    : [];
+
+  if (existing.includes(storagePath)) return;
+
+  await configLoader.save(scope, {
+    ...raw,
+    pathAccess: { ...pa, allowedPaths: [...existing, storagePath] },
+  });
+}
+
+export function setupPathAccessHook(pi: ExtensionAPI): void {
+  pi.on("tool_call", async (event, ctx) => {
+    // Read config live on every invocation
+    const config = configLoader.getConfig();
+    if (!config.features.pathAccess || config.pathAccess.mode === "allow")
+      return;
+
+    const toolName = event.toolName;
+    let absolutePaths: string[] = [];
+
+    const input = event.input as Record<string, unknown>;
+
+    if (["read", "write", "edit", "grep", "find", "ls"].includes(toolName)) {
+      const raw = String(input.file_path ?? input.path ?? "").trim();
+      if (raw) absolutePaths = [resolveFromCwd(raw, ctx.cwd)];
+    } else if (toolName === "bash") {
+      const command = String(input.command ?? "");
+      absolutePaths = await extractBashPathCandidates(command, ctx.cwd);
+    } else {
+      return;
+    }
+
+    if (absolutePaths.length === 0) return;
+
+    // Deduplicate paths
+    absolutePaths = [...new Set(absolutePaths)];
+
+    const pendingGrants: PendingGrant[] = [];
+    const isDirectoryTool = toolName === "ls" || toolName === "find";
+
+    for (const absPath of absolutePaths) {
+      // Build state with live config + pending grants from this loop
+      const resolvedAllowed = resolveAllowedPaths(
+        config.pathAccess.allowedPaths,
+        ctx.cwd,
+      );
+      const pendingAllowedPaths = pendingGrants.map((g) => {
+        const isDir = g.storagePath.endsWith("/");
+        return isDir ? `${g.absolutePath}/` : g.absolutePath;
+      });
+
+      const state: PathAccessState = {
+        cwd: ctx.cwd,
+        mode: config.pathAccess.mode,
+        allowedPaths: [...resolvedAllowed, ...pendingAllowedPaths],
+        hasUI: ctx.hasUI,
+      };
+
+      const displayPath = normalizeForDisplay(absPath, ctx.cwd);
+      const decision = checkPathAccess(absPath, displayPath, state);
+
+      if (decision.kind === "allow") continue;
+
+      if (decision.kind === "deny") {
+        emitBlocked(pi, {
+          feature: "pathAccess",
+          toolName,
+          input: event.input,
+          reason: decision.reason,
+        });
+        return { block: true, reason: decision.reason };
+      }
+
+      // decision.kind === "ask"
+      const parentDir = dirname(absPath);
+      const displayDir = normalizeForDisplay(parentDir, ctx.cwd);
+      const showFileOptions = !isDirectoryTool;
+
+      const result = await ctx.ui.custom<PromptResult>(
+        createPromptComponent(
+          toolName,
+          displayPath,
+          displayDir,
+          ctx.cwd,
+          showFileOptions,
+        ),
+      );
+
+      // Handle "once" grants: just continue, do NOT add to pending
+      if (result === "allow-file-once" || result === "allow-dir-once") {
+        continue;
+      }
+
+      // Handle session/always grants
+      if (result === "allow-file-session" || result === "allow-file-always") {
+        const scope = result === "allow-file-session" ? "memory" : "local";
+        const storage = toStorageForm(absPath, false);
+        pendingGrants.push({
+          storagePath: storage,
+          scope,
+          absolutePath: absPath,
+        });
+        continue;
+      }
+
+      if (result === "allow-dir-session" || result === "allow-dir-always") {
+        const scope = result === "allow-dir-session" ? "memory" : "local";
+        const dirPath = isDirectoryTool ? absPath : parentDir;
+
+        if (isGrantTooBroad(dirPath)) {
+          ctx.ui.notify(
+            `Cannot grant access to ${normalizeForDisplay(dirPath, ctx.cwd)}/ — too broad. Treating as allow once.`,
+            "warning",
+          );
+          continue;
+        }
+
+        const storage = toStorageForm(dirPath, true);
+        pendingGrants.push({
+          storagePath: storage,
+          scope,
+          absolutePath: dirPath,
+        });
+        continue;
+      }
+
+      // result === "deny"
+      const reason = "User denied access outside working directory";
+      emitBlocked(pi, {
+        feature: "pathAccess",
+        toolName,
+        input: event.input,
+        reason,
+        userDenied: true,
+      });
+      return { block: true, reason };
+    }
+
+    // Persist grants only after ALL targets passed
+    for (const grant of pendingGrants) {
+      await persistGrant(grant.storagePath, grant.scope);
+    }
+
+    return;
+  });
+}

--- a/src/utils/bash-paths.test.ts
+++ b/src/utils/bash-paths.test.ts
@@ -1,0 +1,91 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { extractBashPathCandidates } from "./bash-paths";
+
+const CWD = "/work/project";
+const HOME = homedir();
+
+describe("extractBashPathCandidates", () => {
+  describe("when command has path arguments", () => {
+    it("extracts a single absolute path", async () => {
+      expect(await extractBashPathCandidates("cat /etc/hosts", CWD)).toEqual([
+        "/etc/hosts",
+      ]);
+    });
+
+    it("extracts multiple absolute paths", async () => {
+      expect(await extractBashPathCandidates("cp /a /b", CWD)).toEqual([
+        "/a",
+        "/b",
+      ]);
+    });
+
+    it("resolves a relative path with ./ against cwd", async () => {
+      expect(await extractBashPathCandidates("cat ./foo/bar", CWD)).toEqual([
+        "/work/project/foo/bar",
+      ]);
+    });
+
+    it("expands ~ to home", async () => {
+      expect(await extractBashPathCandidates("cat ~/file", CWD)).toEqual([
+        `${HOME}/file`,
+      ]);
+    });
+
+    it("detects Windows-style paths", async () => {
+      const result = await extractBashPathCandidates("type C:\\foo\\bar", CWD);
+      expect(result.length).toBeGreaterThan(0);
+      // On POSIX, resolve() treats backslash path as a single component under cwd
+      expect(result[0]).toContain("C:\\foo\\bar");
+    });
+  });
+
+  describe("when command has flags and redirects", () => {
+    it("ignores flag arguments", async () => {
+      expect(await extractBashPathCandidates("ls -la /tmp", CWD)).toEqual([
+        "/tmp",
+      ]);
+    });
+
+    it("extracts redirect targets", async () => {
+      expect(
+        await extractBashPathCandidates("echo foo > /tmp/out", CWD),
+      ).toEqual(["/tmp/out"]);
+    });
+  });
+
+  describe("when command has no path-like tokens", () => {
+    it("returns an empty array for bare filenames (no separators)", async () => {
+      expect(await extractBashPathCandidates("cat README.md", CWD)).toEqual([]);
+    });
+
+    it("returns an empty array for commands with no file arguments", async () => {
+      expect(await extractBashPathCandidates("echo hello", CWD)).toEqual([]);
+    });
+  });
+
+  describe("when command uses quoting", () => {
+    it("handles quoted paths with spaces", async () => {
+      expect(
+        await extractBashPathCandidates('cat "/tmp/hello world"', CWD),
+      ).toEqual(["/tmp/hello world"]);
+    });
+  });
+
+  describe("when command has duplicate paths", () => {
+    it("deduplicates results", async () => {
+      expect(await extractBashPathCandidates("cat /a /a", CWD)).toEqual(["/a"]);
+    });
+  });
+
+  describe("when command is malformed", () => {
+    it("falls back to regex tokenization on parse failure", async () => {
+      // Unbalanced quote triggers parse error; regex fallback still finds paths
+      const result = await extractBashPathCandidates(
+        "cat /tmp/foo 'unterminated",
+        CWD,
+      );
+      expect(result).toContain("/tmp/foo");
+    });
+  });
+});

--- a/src/utils/bash-paths.ts
+++ b/src/utils/bash-paths.ts
@@ -1,0 +1,96 @@
+import { resolve } from "node:path";
+import { parse } from "@aliou/sh";
+import { expandGlob, hasGlobChars } from "./glob-expander";
+import { expandHomePath } from "./path";
+import { walkCommands, wordToString } from "./shell-utils";
+
+/**
+ * Heuristic: is this token likely a filesystem path?
+ * Intentionally conservative — only structural signals.
+ * Known false positives: "application/json", URL paths. These cause
+ * spurious prompts in ask mode but are safe (better to over-prompt than miss).
+ * Known false negatives: bare filenames without path separators (e.g. "README.md").
+ * These are usually cwd-relative and would pass the boundary check anyway.
+ */
+function maybePathLike(token: string): boolean {
+  if (token.includes("/")) return true;
+  if (token.includes("\\")) return true;
+  if (/^[A-Za-z]:[\\/]/.test(token)) return true;
+  if (token.startsWith("~")) return true;
+  return false;
+}
+
+async function expandCandidate(
+  candidate: string,
+  cwd: string,
+): Promise<string[]> {
+  if (!hasGlobChars(candidate)) return [candidate];
+  const matches = await expandGlob(candidate, { cwd });
+  return matches.length > 0 ? matches : [candidate];
+}
+
+/**
+ * Extract path-like candidates from a bash command string.
+ * Returns absolute paths. Best-effort: uses AST parsing with regex fallback.
+ * Does NOT filter by any policy — returns all path-like arguments.
+ */
+export async function extractBashPathCandidates(
+  command: string,
+  cwd: string,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  const addCandidate = async (
+    token: string,
+    forcePath = false,
+  ): Promise<void> => {
+    if (!token || token.startsWith("-")) return;
+    if (!forcePath && !maybePathLike(token)) return;
+
+    const expanded = await expandCandidate(token, cwd);
+    for (const file of expanded) {
+      const abs = resolve(cwd, expandHomePath(file));
+      if (!seen.has(abs)) {
+        seen.add(abs);
+        results.push(abs);
+      }
+    }
+  };
+
+  try {
+    const { ast } = parse(command);
+    const pending: Promise<void>[] = [];
+
+    walkCommands(ast, (cmd) => {
+      const words = (cmd.words ?? []).map(wordToString);
+      for (let i = 1; i < words.length; i++) {
+        pending.push(addCandidate(words[i] as string));
+      }
+      for (const redir of cmd.redirects ?? []) {
+        pending.push(addCandidate(wordToString(redir.target), true));
+      }
+      return false;
+    });
+
+    await Promise.all(pending);
+    return results;
+  } catch {
+    // Fallback: regex tokenization
+    const tokenRegex = /"([^"]+)"|'([^']+)'|`([^`]+)`|([^\s"'`<>|;&]+)/g;
+    for (const match of command.matchAll(tokenRegex)) {
+      const token = match[1] ?? match[2] ?? match[3] ?? match[4] ?? "";
+      if (token && !token.startsWith("-") && maybePathLike(token)) {
+        const expanded = await expandCandidate(token, cwd);
+        for (const file of expanded) {
+          const abs = resolve(cwd, expandHomePath(file));
+          if (!seen.has(abs)) {
+            seen.add(abs);
+            results.push(abs);
+          }
+        }
+      }
+    }
+    return results;
+  }
+}

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -4,7 +4,7 @@ export const GUARDRAILS_BLOCKED_EVENT = "guardrails:blocked";
 export const GUARDRAILS_DANGEROUS_EVENT = "guardrails:dangerous";
 
 export interface GuardrailsBlockedEvent {
-  feature: "policies" | "permissionGate";
+  feature: "policies" | "permissionGate" | "pathAccess";
   toolName: string;
   input: Record<string, unknown>;
   reason: string;

--- a/src/utils/path-access.test.ts
+++ b/src/utils/path-access.test.ts
@@ -1,0 +1,154 @@
+import { assert, describe, expect, it } from "vitest";
+import {
+  checkPathAccess,
+  isPathAllowed,
+  type PathAccessState,
+} from "./path-access";
+
+describe("isPathAllowed", () => {
+  describe("when allowedPaths is empty", () => {
+    it("returns false", () => {
+      expect(isPathAllowed("/foo/bar", [])).toBe(false);
+    });
+  });
+
+  describe("when entry is an exact file grant", () => {
+    it.each([
+      { desc: "matches the exact file", path: "/foo/bar", expected: true },
+      {
+        desc: "does not match a sibling file",
+        path: "/foo/other",
+        expected: false,
+      },
+      {
+        desc: "does not match the containing directory",
+        path: "/foo",
+        expected: false,
+      },
+    ])("$desc", ({ path, expected }) => {
+      expect(isPathAllowed(path, ["/foo/bar"])).toBe(expected);
+    });
+  });
+
+  describe("when entry is a directory grant (trailing /)", () => {
+    it.each([
+      {
+        desc: "matches the directory itself",
+        path: "/foo/bar",
+        expected: true,
+      },
+      { desc: "matches a direct child", path: "/foo/bar/baz", expected: true },
+      {
+        desc: "matches a grandchild",
+        path: "/foo/bar/baz/qux",
+        expected: true,
+      },
+      {
+        desc: "does not match a prefix-collision path like /foo/barbaz",
+        path: "/foo/barbaz",
+        expected: false,
+      },
+    ])("$desc", ({ path, expected }) => {
+      expect(isPathAllowed(path, ["/foo/bar/"])).toBe(expected);
+    });
+  });
+
+  describe("when allowedPaths has multiple entries", () => {
+    it("returns true if any entry matches", () => {
+      expect(isPathAllowed("/b", ["/a", "/b"])).toBe(true);
+    });
+
+    it.each([
+      { path: "/foo/file.ts", expected: true },
+      { path: "/bar/anything", expected: true },
+      { path: "/foo/other.ts", expected: false },
+      { path: "/baz", expected: false },
+    ])("with mixed file + directory grants, returns $expected for $path", ({
+      path,
+      expected,
+    }) => {
+      expect(isPathAllowed(path, ["/foo/file.ts", "/bar/"])).toBe(expected);
+    });
+  });
+});
+
+describe("checkPathAccess", () => {
+  const cwd = "/work/project";
+  const base = (overrides: Partial<PathAccessState> = {}): PathAccessState => ({
+    cwd,
+    mode: "ask",
+    allowedPaths: [],
+    hasUI: true,
+    ...overrides,
+  });
+
+  describe("when mode is allow", () => {
+    it("always returns allow, even for paths outside cwd and without UI", () => {
+      const state = base({ mode: "allow", hasUI: false, allowedPaths: [] });
+      expect(checkPathAccess("/etc/hosts", "/etc/hosts", state).kind).toBe(
+        "allow",
+      );
+      expect(checkPathAccess("/work/project/src", "src", state).kind).toBe(
+        "allow",
+      );
+    });
+  });
+
+  describe("when path is inside cwd", () => {
+    it.each([
+      { mode: "block" as const },
+      { mode: "ask" as const },
+    ])("returns allow in $mode mode", ({ mode }) => {
+      const state = base({ mode });
+      expect(
+        checkPathAccess("/work/project/src/file", "src/file", state).kind,
+      ).toBe("allow");
+    });
+
+    it("returns allow when path equals cwd", () => {
+      expect(checkPathAccess(cwd, ".", base({ mode: "ask" })).kind).toBe(
+        "allow",
+      );
+    });
+  });
+
+  describe("when path is outside cwd and mode is block", () => {
+    it("returns deny with the displayPath in the reason", () => {
+      const state = base({ mode: "block" });
+      const decision = checkPathAccess("/etc/hosts", "/etc/hosts", state);
+      assert(decision.kind === "deny", "expected deny decision");
+      expect(decision.reason).toContain("/etc/hosts");
+    });
+
+    it("returns allow when the path is in allowedPaths", () => {
+      const state = base({ mode: "block", allowedPaths: ["/etc/hosts"] });
+      expect(checkPathAccess("/etc/hosts", "/etc/hosts", state).kind).toBe(
+        "allow",
+      );
+    });
+  });
+
+  describe("when path is outside cwd and mode is ask", () => {
+    it("returns ask with displayPath when UI is available", () => {
+      const state = base({ mode: "ask", hasUI: true });
+      const decision = checkPathAccess("/etc/hosts", "/etc/hosts", state);
+      assert(decision.kind === "ask", "expected ask decision");
+      expect(decision.displayPath).toBe("/etc/hosts");
+      expect(decision.absolutePath).toBe("/etc/hosts");
+    });
+
+    it("returns deny with a 'no UI' reason when UI is unavailable", () => {
+      const state = base({ mode: "ask", hasUI: false });
+      const decision = checkPathAccess("/etc/hosts", "/etc/hosts", state);
+      assert(decision.kind === "deny", "expected deny decision");
+      expect(decision.reason).toContain("no UI");
+    });
+
+    it("returns allow when the path is in allowedPaths (no prompt)", () => {
+      const state = base({ mode: "ask", allowedPaths: ["/etc/hosts"] });
+      expect(checkPathAccess("/etc/hosts", "/etc/hosts", state).kind).toBe(
+        "allow",
+      );
+    });
+  });
+});

--- a/src/utils/path-access.ts
+++ b/src/utils/path-access.ts
@@ -1,0 +1,62 @@
+import { isWithinBoundary } from "./path";
+
+export type PathDecision =
+  | { kind: "allow" }
+  | { kind: "deny"; reason: string }
+  | { kind: "ask"; absolutePath: string; displayPath: string };
+
+export interface PathAccessState {
+  cwd: string;
+  mode: "allow" | "ask" | "block";
+  allowedPaths: string[]; // already resolved to absolute, with trailing / convention
+  hasUI: boolean;
+}
+
+/**
+ * Check if an absolute path is covered by the allowedPaths list.
+ * - Entries ending in "/" are directory grants (boundary/prefix match).
+ * - Entries without trailing "/" are exact file grants.
+ */
+export function isPathAllowed(
+  absPath: string,
+  allowedPaths: string[],
+): boolean {
+  for (const entry of allowedPaths) {
+    if (entry.endsWith("/")) {
+      const dirPath = entry.slice(0, -1);
+      if (isWithinBoundary(absPath, dirPath)) return true;
+    } else {
+      if (absPath === entry) return true;
+    }
+  }
+  return false;
+}
+
+export function checkPathAccess(
+  absolutePath: string,
+  displayPath: string,
+  state: PathAccessState,
+): PathDecision {
+  if (state.mode === "allow") return { kind: "allow" };
+
+  if (isWithinBoundary(absolutePath, state.cwd)) return { kind: "allow" };
+
+  if (isPathAllowed(absolutePath, state.allowedPaths)) return { kind: "allow" };
+
+  if (state.mode === "block") {
+    return {
+      kind: "deny",
+      reason: `Access to ${displayPath} is blocked (outside working directory).`,
+    };
+  }
+
+  // mode === "ask"
+  if (!state.hasUI) {
+    return {
+      kind: "deny",
+      reason: `Access to ${displayPath} is blocked (outside working directory, no UI to confirm).`,
+    };
+  }
+
+  return { kind: "ask", absolutePath, displayPath };
+}

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,177 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  expandHomePath,
+  isWithinBoundary,
+  normalizeForDisplay,
+  resolveFromCwd,
+  toStorageForm,
+} from "./path";
+
+const HOME = homedir();
+
+describe("expandHomePath", () => {
+  it.each([
+    { desc: "bare ~", input: "~", expected: HOME },
+    { desc: "~/foo", input: "~/foo", expected: `${HOME}/foo` },
+    {
+      desc: "~\\foo (Windows tilde)",
+      input: "~\\foo",
+      expected: `${HOME}/foo`,
+    },
+    {
+      desc: "an absolute path",
+      input: "/absolute/path",
+      expected: "/absolute/path",
+    },
+    {
+      desc: "a relative path",
+      input: "relative/path",
+      expected: "relative/path",
+    },
+    { desc: "an empty string", input: "", expected: "" },
+  ])("given $desc, returns the expanded path", ({ input, expected }) => {
+    expect(expandHomePath(input)).toBe(expected);
+  });
+});
+
+describe("resolveFromCwd", () => {
+  const cwd = "/some/cwd";
+
+  it.each([
+    {
+      desc: "a relative path",
+      input: "sub/file",
+      expected: "/some/cwd/sub/file",
+    },
+    { desc: "an absolute path", input: "/etc/hosts", expected: "/etc/hosts" },
+    { desc: "a ~ path", input: "~/foo", expected: `${HOME}/foo` },
+    { desc: "'.'", input: ".", expected: "/some/cwd" },
+  ])("given $desc, resolves against cwd", ({ input, expected }) => {
+    expect(resolveFromCwd(input, cwd)).toBe(expected);
+  });
+});
+
+describe("isWithinBoundary", () => {
+  it.each([
+    {
+      desc: "paths are identical",
+      target: "/foo/bar",
+      root: "/foo/bar",
+      expected: true,
+    },
+    {
+      desc: "target is a direct child",
+      target: "/foo/bar/baz",
+      root: "/foo/bar",
+      expected: true,
+    },
+    {
+      desc: "target is a grandchild",
+      target: "/foo/bar/baz/qux",
+      root: "/foo/bar",
+      expected: true,
+    },
+    {
+      desc: "target is a parent",
+      target: "/foo",
+      root: "/foo/bar",
+      expected: false,
+    },
+    {
+      desc: "target is a sibling",
+      target: "/foo/other",
+      root: "/foo/bar",
+      expected: false,
+    },
+    {
+      desc: "target shares a string prefix but is not a child (critical case)",
+      target: "/foo/barbaz",
+      root: "/foo/bar",
+      expected: false,
+    },
+    {
+      desc: "paths are completely unrelated",
+      target: "/tmp",
+      root: "/home/user",
+      expected: false,
+    },
+  ])("when $desc, returns $expected", ({ target, root, expected }) => {
+    expect(isWithinBoundary(target, root)).toBe(expected);
+  });
+});
+
+describe("normalizeForDisplay", () => {
+  const cwd = "/work/project";
+
+  it.each([
+    { desc: "path equals cwd", input: cwd, expected: "." },
+    {
+      desc: "path is a child of cwd",
+      input: "/work/project/src/file.ts",
+      expected: "src/file.ts",
+    },
+    {
+      desc: "path is under home but not cwd",
+      input: `${HOME}/config/file`,
+      expected: "~/config/file",
+    },
+    {
+      desc: "path is outside both cwd and home",
+      input: "/etc/hosts",
+      expected: "/etc/hosts",
+    },
+    { desc: "path is home itself", input: HOME, expected: "~" },
+  ])("when $desc, returns $expected", ({ input, expected }) => {
+    expect(normalizeForDisplay(input, cwd)).toBe(expected);
+  });
+});
+
+describe("toStorageForm", () => {
+  it.each([
+    {
+      desc: "file under home",
+      absPath: `${HOME}/code/file.ts`,
+      isDirectory: false,
+      expected: "~/code/file.ts",
+    },
+    {
+      desc: "directory under home",
+      absPath: `${HOME}/code`,
+      isDirectory: true,
+      expected: "~/code/",
+    },
+    {
+      desc: "absolute file outside home",
+      absPath: "/etc/hosts",
+      isDirectory: false,
+      expected: "/etc/hosts",
+    },
+    {
+      desc: "absolute directory outside home",
+      absPath: "/etc",
+      isDirectory: true,
+      expected: "/etc/",
+    },
+    {
+      desc: "input has trailing slash but isDirectory=false",
+      absPath: "/etc/hosts/",
+      isDirectory: false,
+      expected: "/etc/hosts",
+    },
+    {
+      desc: "input uses Windows backslashes",
+      absPath: "C:\\Users\\foo",
+      isDirectory: false,
+      expected: "C:/Users/foo",
+    },
+    {
+      desc: "input is home itself with isDirectory=true",
+      absPath: HOME,
+      isDirectory: true,
+      expected: "~/",
+    },
+  ])("when $desc, returns $expected", ({ absPath, isDirectory, expected }) => {
+    expect(toStorageForm(absPath, isDirectory)).toBe(expected);
+  });
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,18 +1,74 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 /**
  * Expand a leading tilde to the current user's home directory.
  * Preserves all other paths unchanged.
  */
 export function expandHomePath(input: string): string {
-  if (input === "~") {
-    return homedir();
-  }
-
-  if (input.startsWith("~/")) {
+  if (input === "~") return homedir();
+  if (input.startsWith("~/") || input.startsWith("~\\"))
     return join(homedir(), input.slice(2));
-  }
-
   return input;
+}
+
+export function resolveFromCwd(input: string, cwd: string): string {
+  return resolve(cwd, expandHomePath(input));
+}
+
+/**
+ * Lexical boundary check. Returns true if targetAbsPath equals rootAbsPath
+ * or is a descendant. Both paths must already be resolved (absolute, no ..).
+ * Does NOT resolve symlinks — this is a known limitation.
+ */
+export function isWithinBoundary(
+  targetAbsPath: string,
+  rootAbsPath: string,
+): boolean {
+  const rel = relative(rootAbsPath, targetAbsPath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * Format an absolute path for display:
+ * - relative if inside cwd
+ * - ~/... if under home
+ * - absolute otherwise
+ */
+export function normalizeForDisplay(absPath: string, cwd: string): string {
+  const home = homedir();
+  const rel = relative(cwd, absPath);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel)))
+    return rel || ".";
+  if (
+    absPath === home ||
+    absPath.startsWith(`${home}/`) ||
+    absPath.startsWith(`${home}\\`)
+  ) {
+    return `~${absPath.slice(home.length)}`;
+  }
+  return absPath;
+}
+
+/**
+ * Convert an absolute path to storage form for config persistence.
+ * Uses ~/ for home paths, absolute otherwise. Appends trailing / for directory grants.
+ */
+export function toStorageForm(absPath: string, isDirectory: boolean): string {
+  const home = homedir();
+  let stored: string;
+  if (
+    absPath === home ||
+    absPath.startsWith(`${home}/`) ||
+    absPath.startsWith(`${home}\\`)
+  ) {
+    stored = `~${absPath.slice(home.length)}`;
+  } else {
+    stored = absPath;
+  }
+  // Normalize separators to forward slash for storage
+  stored = stored.replace(/\\/g, "/");
+  if (isDirectory && !stored.endsWith("/")) stored += "/";
+  if (!isDirectory && stored.endsWith("/")) stored = stored.slice(0, -1);
+  return stored;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    mockReset: true,
+  },
+});


### PR DESCRIPTION



> [!NOTE]
> This PR was made by `pi (synthetic/hf:zai-org/GLM-5.1)`

------

<details><summary>Summary by AI:</summary>
<p>

## Summary

Add path access feature: restrict tool access to the current working directory with `allow`/`ask`/`block` modes.

### Modes

- **allow** — no restrictions (default off behavior)
- **ask** — prompt user when a tool targets a path outside the working directory
- **block** — always deny outside-CWD access unless explicitly allowed

### Path allowlists

- `file` entry (no trailing `/`) = exact match
- `directory` entry (trailing `/`) = directory + descendants
- Session grants persist in memory, project grants persist in local config

### Changes

- `src/hooks/path-access.ts` — path-access hook with interactive prompt for ask mode
- `src/utils/bash-paths.ts` — bash path extraction utility for detecting target paths in commands
- `src/utils/path-access.ts` — decision logic and display normalization
- `src/utils/path.ts` — extended path utility functions
- `src/config.ts` — `features.pathAccess` + `pathAccess` config block
- `src/commands/settings-command.ts` — path access section in settings UI
- `src/commands/onboarding.ts` / `onboarding-command.ts` — onboarding step
- `src/utils/events.ts` — `pathAccess` feature in blocked events
- `README.md` / `docs/defaults.md` — documentation
- `.changeset/path-access-feature.md` — minor version bump

### Tests

- Vitest setup + unit tests for bash path extraction, path access decision logic, and path utilities


</p>
</details>