### PR TITLE
fix: go package wildcards (`./...`) treated as file paths

### DIFF
--- a/.changeset/go-package-wildcard-39.md
+++ b/.changeset/go-package-wildcard-39.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Fix go package wildcards (./...) incorrectly treated as file paths, blocking commands like `go test ./...`

--- a/src/core/shell/command-args.test.ts
+++ b/src/core/shell/command-args.test.ts
@@ -91,4 +91,52 @@ describe("classifyCommandArgs", () => {
     expect(tokens("sort", ["-t", "/", "./file"])).toEqual(["./file"]);
     expect(tokens("tr", ["/", ":"])).toEqual([]);
   });
+
+  describe("go subcommand", () => {
+    it("skips Go package wildcard patterns", () => {
+      expect(tokens("go", ["test", "./..."])).toEqual([]);
+    });
+
+    it("keeps go run .go file operands", () => {
+      expect(tokens("go", ["run", "main.go"])).toEqual(["main.go"]);
+    });
+
+    it("skips non-.go positionals for go run", () => {
+      expect(tokens("go", ["run", "-exec", "/bin/env", "main.go"])).toEqual([
+        "main.go",
+      ]);
+    });
+
+    it("skips package patterns for build/vet/list", () => {
+      expect(tokens("go", ["build", "./..."])).toEqual([]);
+      expect(tokens("go", ["vet", "./pkg/..."])).toEqual([]);
+      expect(tokens("go", ["list", "./..."])).toEqual([]);
+    });
+
+    it("keeps file-valued flags", () => {
+      expect(tokens("go", ["build", "-modfile", "./go.mod", "./..."])).toEqual([
+        "./go.mod",
+      ]);
+    });
+
+    it("keeps -o flag value for go build", () => {
+      expect(tokens("go", ["build", "-o", "./bin/app", "./..."])).toEqual([
+        "./bin/app",
+      ]);
+    });
+
+    it("handles -C global flag before subcommand", () => {
+      expect(tokens("go", ["-C", "/tmp", "test", "./..."])).toEqual([]);
+    });
+
+    it("handles -C joined form before subcommand", () => {
+      expect(tokens("go", ["-C=/tmp", "test", "./..."])).toEqual([]);
+    });
+
+    it("keeps go run .go file operands with -C", () => {
+      expect(tokens("go", ["-C", "/tmp", "run", "main.go"])).toEqual([
+        "main.go",
+      ]);
+    });
+  });
 });

--- a/src/core/shell/command-args.ts
+++ b/src/core/shell/command-args.ts
@@ -32,6 +32,7 @@ export function classifyCommandArgs(
   ) {
     return classifyInterpreterArgs(cmd, args);
   }
+  if (cmd === "go") return classifyGoArgs(args);
   if (cmd === "cut")
     return skipOptionValues(args, new Set(["-d", "--delimiter"]));
   if (cmd === "sort")
@@ -221,6 +222,76 @@ function skipOptionValues(
       continue;
     }
     out.push({ token: arg });
+  }
+  return out;
+}
+
+/**
+ * Classify `go` subcommand arguments.
+ *
+ * Go commands take package patterns, not file paths, as positional args
+ * for most subcommands. Package patterns like `./...`, `pkg/...`,
+ * or `github.com/user/repo/...` use Go's `...` wildcard and are not
+ * filesystem paths.
+ *
+ * `go run` is an exception: it takes .go file operands, emitted with
+ * `forcePath` since bare filenames like `main.go` don't pass
+ * `maybePathLike`.
+ *
+ * File-valued flags (e.g. `-o`, `-modfile`, `-overlay`) are kept
+ * so that policy checks can still gate them.
+ *
+ * Global flags like `-C dir` are handled before subcommand detection
+ * so their values aren't mistaken for the subcommand.
+ */
+function classifyGoArgs(args: string[]): ClassifiedArg[] {
+  const out: ClassifiedArg[] = [];
+  const fileFlags = new Set(["-o", "-modfile", "-overlay"]);
+
+  // Global flags that consume a value and must be skipped before
+  // subcommand detection. E.g. `go -C /tmp test ./...`
+  const globalFlagsWithValues = new Set(["-C"]);
+
+  let subcommand: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string;
+
+    // Handle file-valued flags
+    if (fileFlags.has(arg)) {
+      if (args[i + 1]) out.push({ token: args[++i] as string });
+      continue;
+    }
+
+    // Handle joined file flags like -o=./bin/app
+    if (arg.startsWith("-o=")) {
+      out.push({ token: arg.slice(3) });
+      continue;
+    }
+
+    // Skip global flags with values before subcommand detection
+    if (!subcommand && globalFlagsWithValues.has(arg)) {
+      i++; // skip value
+      continue;
+    }
+    if (!subcommand && arg.startsWith("-C=")) {
+      // joined form -C=/tmp
+      continue;
+    }
+
+    if (isOption(arg)) continue;
+
+    // First non-flag positional is the subcommand
+    if (!subcommand) {
+      subcommand = arg;
+      continue;
+    }
+
+    // `go run` takes .go file operands; emit with forcePath since
+    // bare filenames like main.go don't pass maybePathLike.
+    // All other subcommands take package patterns; skip them.
+    if (subcommand === "run" && arg.endsWith(".go")) {
+      out.push({ token: arg, forcePath: true });
+    }
   }
   return out;
 }

--- a/src/shared/paths/bash-paths.test.ts
+++ b/src/shared/paths/bash-paths.test.ts
@@ -6,6 +6,27 @@ const CWD = "/work/project";
 const HOME = homedir();
 
 describe("extractBashPathCandidates", () => {
+  it("does not extract go package wildcard patterns as paths", async () => {
+    const result = await extractBashPathCandidates("go test ./...", CWD);
+
+    expect(result).toEqual([]);
+  });
+
+  it("extracts go run .go file operands", async () => {
+    const result = await extractBashPathCandidates("go run main.go", CWD);
+
+    expect(result).toEqual(["/work/project/main.go"]);
+  });
+
+  it("handles go -C global flag", async () => {
+    const result = await extractBashPathCandidates(
+      "go -C /tmp test ./...",
+      CWD,
+    );
+
+    expect(result).toEqual([]);
+  });
+
   describe("when a command has regular expression arguments", () => {
     it("ignores sed expressions and extracts file operands", async () => {
       const result = await extractBashPathCandidates(


### PR DESCRIPTION
add a classifer for go commands/arguments, the same way we do it for awk/sed and others that can take args that look like paths but aren't.

------

<details><summary>Summary by zai-org/GLM-5.1:</summary>
<p>

Fixes #39

`go test ./...` was incorrectly identified as accessing path `/path/to/cwd/...`, which blocked the command even when cwd was allowed.

**Root cause:** No `go` command classifier existed, so Go package patterns like `./...` passed through as generic positional args and were treated as filesystem paths by `maybePathLike`.

**Fix:** Add `classifyGoArgs()` in `command-args.ts`:
- Identifies the subcommand (first non-flag positional)
- Handles `-C` global flag before subcommand detection (both `-C dir` and `-C=dir` forms)
- Skips all positional args for package-oriented subcommands (test, build, vet, list, etc.)
- Emits `.go` file operands for `go run` with `forcePath: true` (bare filenames like `main.go` don't pass `maybePathLike`)
- Keeps file-valued flags (`-o`, `-modfile`, `-overlay`)

`maybePathLike()` remains purely generic — no Go-specific knowledge. Command-specific filtering is the right layer (same pattern as awk/sed/grep classifiers).

</p>
</details>