### PR TITLE
Add guardrails:action:prompted event

### DIFF
--- a/.changeset/guardrails-action-prompted-event.md
+++ b/.changeset/guardrails-action-prompted-event.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add `guardrails:action:prompted` event that fires when guardrails shows an interactive prompt to the user, before the user has responded. This complements the existing `guardrails:action:blocked` (post-decision) and `guardrails:risk:detected` events.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ tests/
 - Config migrations are predicate-based (`shouldRun`) using structural checks; do not rely on lexicographic version string comparisons
 - Runtime code must only handle current config/core shapes. Old config shapes belong exclusively in migrations; do not add runtime compatibility branches for legacy config.
 - `config.version` is a schema marker for debugging/inspection, not the package version
-- Events emitted on the pi event bus for inter-extension communication are defined in `src/shared/events.ts`. Current public events are `guardrails:action:blocked`, `guardrails:risk:detected`, `guardrails:feature:request`, and `guardrails:feature:register`.
+- Events emitted on the pi event bus for inter-extension communication are defined in `src/shared/events.ts`. Current public events are `guardrails:action:blocked`, `guardrails:action:prompted`, `guardrails:risk:detected`, `guardrails:feature:request`, and `guardrails:feature:register`.
 
 ## Documentation
 

--- a/extensions/path-access/index.ts
+++ b/extensions/path-access/index.ts
@@ -9,6 +9,7 @@ import { configLoader } from "../../src/shared/config";
 import {
   createFeatureRegisterPayload,
   emitActionBlocked,
+  emitActionPrompted,
   GUARDRAILS_FEATURE_REGISTER_EVENT,
   GUARDRAILS_FEATURE_REQUEST_EVENT,
 } from "../../src/shared/events";
@@ -85,6 +86,17 @@ export default async function pathAccess(pi: ExtensionAPI) {
       const parentDir = dirname(absolutePath);
       const showFileOptions =
         event.toolName !== "ls" && event.toolName !== "find";
+      emitActionPrompted(pi, {
+        feature: "pathAccess",
+        action: safety.action,
+        reason: safety.reason,
+        prompt: {
+          kind: "confirmation",
+          metadata: safety.metadata,
+        },
+        context: { toolName: event.toolName, input },
+      });
+
       const result = await ctx.ui.custom<PromptResult>(
         createPathAccessPromptComponent(
           event.toolName,

--- a/extensions/permission-gate/index.ts
+++ b/extensions/permission-gate/index.ts
@@ -7,6 +7,7 @@ import { configLoader } from "../../src/shared/config";
 import {
   createFeatureRegisterPayload,
   emitActionBlocked,
+  emitActionPrompted,
   emitRiskDetected,
   GUARDRAILS_FEATURE_REGISTER_EVENT,
   GUARDRAILS_FEATURE_REQUEST_EVENT,
@@ -89,6 +90,17 @@ export default async function permissionGate(pi: ExtensionAPI) {
     }
 
     type ConfirmResult = "allow" | "allow-session" | "deny";
+    emitActionPrompted(pi, {
+      feature: "permissionGate",
+      action: safety.action,
+      reason: safety.reason,
+      prompt: {
+        kind: "permission",
+        metadata: safety.metadata,
+      },
+      context: { toolName: "bash", input: event.input },
+    });
+
     let result = await ctx.ui.custom<ConfirmResult>(
       createPermissionGateConfirmComponent(command, safety.reason),
     );

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -5,6 +5,7 @@ export const GUARDRAILS_ACTION_BLOCKED_EVENT = "guardrails:action:blocked";
 export const GUARDRAILS_RISK_DETECTED_EVENT = "guardrails:risk:detected";
 export const GUARDRAILS_FEATURE_REQUEST_EVENT = "guardrails:feature:request";
 export const GUARDRAILS_FEATURE_REGISTER_EVENT = "guardrails:feature:register";
+export const GUARDRAILS_ACTION_PROMPTED_EVENT = "guardrails:action:prompted";
 
 export type GuardrailsFeatureId = "policies" | "permissionGate" | "pathAccess";
 
@@ -39,6 +40,22 @@ export type GuardrailsActionBlockedPayload<TMeta = unknown> =
     reason: string;
     block: {
       source: GuardrailsBlockSource;
+      metadata?: TMeta;
+    };
+    context?: {
+      toolName?: string;
+      input?: Record<string, unknown>;
+    };
+  };
+
+export type GuardrailsActionPromptedPayload<TMeta = unknown> =
+  GuardrailsEventBase & {
+    action: Action;
+    reason: string;
+    prompt: {
+      /** What kind of prompt was shown */
+      kind: "confirmation" | "permission";
+      /** The feature-specific metadata about the risk */
       metadata?: TMeta;
     };
     context?: {
@@ -93,6 +110,17 @@ export function emitRiskDetected<TMeta = unknown>(
   event: Omit<GuardrailsRiskDetectedPayload<TMeta>, "source" | "timestamp">,
 ): void {
   pi.events.emit(GUARDRAILS_RISK_DETECTED_EVENT, {
+    source: "guardrails",
+    timestamp: timestamp(),
+    ...event,
+  });
+}
+
+export function emitActionPrompted<TMeta = unknown>(
+  pi: ExtensionAPI,
+  event: Omit<GuardrailsActionPromptedPayload<TMeta>, "source" | "timestamp">,
+): void {
+  pi.events.emit(GUARDRAILS_ACTION_PROMPTED_EVENT, {
     source: "guardrails",
     timestamp: timestamp(),
     ...event,


### PR DESCRIPTION
Hi,
Thanks for a great extension

This adds a new public event `guardrails:action:prompted` that fires when guardrails shows an interactive prompt to the user, before the user has responded.

We've got `action:blocked` (post-decision) and `risk:detected` but nothing that's saying
> hey, i'm waiting for an end user here

Just a side note `.pi/settings.json` references two npm extensions which aren't public, which caused my clanker to refuse to open 