### PR TITLE
fix: ignore ctx7 docs library ids as paths

### DIFF
--- a/.changeset/ctx7-library-id-paths.md
+++ b/.changeset/ctx7-library-id-paths.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Avoid treating Context7 docs library IDs as filesystem paths in shell guardrails.

--- a/src/core/shell/command-args.test.ts
+++ b/src/core/shell/command-args.test.ts
@@ -92,6 +92,49 @@ describe("classifyCommandArgs", () => {
     expect(tokens("tr", ["/", ":"])).toEqual([]);
   });
 
+  describe("ctx7 docs command", () => {
+    it("skips slash-prefixed library IDs", () => {
+      expect(
+        tokens("ctx7", ["docs", "/websites/apisix_apache_apisix", "routes"]),
+      ).toEqual([]);
+    });
+
+    it("skips library IDs through npx ctx7", () => {
+      expect(
+        tokens("npx", [
+          "ctx7@latest",
+          "docs",
+          "/websites/apisix_apache_apisix",
+          "routes",
+        ]),
+      ).toEqual([]);
+    });
+
+    it("skips library IDs through npx --yes ctx7", () => {
+      expect(
+        tokens("npx", [
+          "--yes",
+          "ctx7@latest",
+          "docs",
+          "/websites/apisix_apache_apisix",
+          "routes",
+        ]),
+      ).toEqual([]);
+    });
+
+    it("skips library IDs through npx -y ctx7", () => {
+      expect(
+        tokens("npx", [
+          "-y",
+          "ctx7@latest",
+          "docs",
+          "/websites/apisix_apache_apisix",
+          "routes",
+        ]),
+      ).toEqual([]);
+    });
+  });
+
   describe("go subcommand", () => {
     it("skips Go package wildcard patterns", () => {
       expect(tokens("go", ["test", "./..."])).toEqual([]);

--- a/src/core/shell/command-args.ts
+++ b/src/core/shell/command-args.ts
@@ -33,6 +33,8 @@ export function classifyCommandArgs(
     return classifyInterpreterArgs(cmd, args);
   }
   if (cmd === "go") return classifyGoArgs(args);
+  if (cmd === "ctx7") return classifyCtx7Args(args);
+  if (cmd === "npx") return classifyNpxArgs(args);
   if (cmd === "cut")
     return skipOptionValues(args, new Set(["-d", "--delimiter"]));
   if (cmd === "sort")
@@ -224,6 +226,40 @@ function skipOptionValues(
     out.push({ token: arg });
   }
   return out;
+}
+
+function isCtx7PackageSpec(token: string): boolean {
+  return /^ctx7(?:@.+)?$/.test(token);
+}
+
+/**
+ * Classify Context7 docs arguments.
+ *
+ * `ctx7 docs` uses slash-prefixed library IDs such as `/facebook/react`
+ * and `/websites/apisix_apache_apisix`. They are identifiers, not
+ * filesystem paths.
+ */
+function classifyCtx7Args(args: string[]): ClassifiedArg[] {
+  if (args[0] === "docs") return [];
+
+  return args.map((token) => ({ token }));
+}
+
+/**
+ * Unwrap the common `npx ctx7@latest docs ...` form.
+ */
+function classifyNpxArgs(args: string[]): ClassifiedArg[] {
+  let packageIndex = 0;
+  while (args[packageIndex] === "-y" || args[packageIndex] === "--yes") {
+    packageIndex++;
+  }
+
+  const packageSpec = args[packageIndex];
+  if (packageSpec && isCtx7PackageSpec(packageSpec)) {
+    return classifyCtx7Args(args.slice(packageIndex + 1));
+  }
+
+  return args.map((token) => ({ token }));
 }
 
 /**

--- a/src/shared/paths/bash-paths.test.ts
+++ b/src/shared/paths/bash-paths.test.ts
@@ -6,6 +6,15 @@ const CWD = "/work/project";
 const HOME = homedir();
 
 describe("extractBashPathCandidates", () => {
+  it("does not extract ctx7 docs library IDs as paths", async () => {
+    const result = await extractBashPathCandidates(
+      'npx ctx7@latest docs /websites/apisix_apache_apisix "routes"',
+      CWD,
+    );
+
+    expect(result).toEqual([]);
+  });
+
   it("does not extract go package wildcard patterns as paths", async () => {
     const result = await extractBashPathCandidates("go test ./...", CWD);
 


### PR DESCRIPTION
## Summary

Fixes #49.

`ctx7 docs` uses slash-prefixed library IDs such as `/websites/apisix_apache_apisix`. Those are Context7 identifiers, not local filesystem paths. This adds a small command-specific classifier, following the existing awk/sed/go classifier pattern, so `ctx7 docs ...` and common `npx ctx7@latest docs ...` invocations do not emit those IDs as path candidates.

## Changes

- Add a `ctx7` command classifier for `docs` arguments.
- Add a narrow `npx` unwrap for common `npx [-y|--yes] ctx7@latest docs ...` usage.
- Add unit coverage in `command-args.test.ts` and `bash-paths.test.ts`.
- Add a patch changeset.

## Validation

- `npx --yes pnpm@10.26.1 test`
- `npx --yes pnpm@10.26.1 typecheck`
- `npx --yes pnpm@10.26.1 lint`
