### PR TITLE
feat: support ignored bash args for path access

### DIFF
--- a/.changeset/ignored-bash-args.md
+++ b/.changeset/ignored-bash-args.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add pathAccess.ignoredBashArgs for command-scoped bash arguments that should not be treated as filesystem paths.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The `path-access` extension checks tool calls that target paths outside the curr
 
 It can allow, block, or ask before Pi accesses files elsewhere on your machine. In ask mode, you can allow one file or a directory once, for the session, or always.
 
+Advanced users can configure `pathAccess.ignoredBashArgs` for command-scoped bash arguments that look like paths but are CLI identifiers. These rules only affect bash argv extraction, not redirects or direct file tools.
+
 [![Guardrails path access prompt walkthrough](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/path-access.gif)](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/path-access.mp4)
 
 ### permission-gate

--- a/extensions/path-access/index.ts
+++ b/extensions/path-access/index.ts
@@ -47,7 +47,14 @@ export default async function pathAccess(pi: ExtensionAPI) {
 
     const input = event.input as Record<string, unknown>;
     const targets = [
-      ...new Set(await targetsForTool(event.toolName, input, ctx.cwd)),
+      ...new Set(
+        await targetsForTool(
+          event.toolName,
+          input,
+          ctx.cwd,
+          config.pathAccess.ignoredBashArgs,
+        ),
+      ),
     ];
     const acceptedGrants: PendingPathGrant[] = [];
 

--- a/extensions/path-access/targets.test.ts
+++ b/extensions/path-access/targets.test.ts
@@ -19,6 +19,35 @@ describe("targetsForTool", () => {
     ).resolves.toEqual([join(cwd, "README.md")]);
   });
 
+  it("filters configured ignored bash args", async () => {
+    const cwd = "/repo";
+    vol.fromJSON({ "/repo/README.md": "hello" });
+
+    await expect(
+      targetsForTool(
+        "bash",
+        { command: "tool docs /library/id ./README.md" },
+        cwd,
+        [
+          {
+            command: "tool",
+            subcommands: ["docs"],
+            argPattern: "^/library/",
+            regex: true,
+          },
+        ],
+      ),
+    ).resolves.toEqual([join(cwd, "README.md")]);
+  });
+
+  it("does not apply ignored bash args to direct file tools", async () => {
+    await expect(
+      targetsForTool("read", { path: "/library/id" }, "/repo", [
+        { command: "read", argPattern: "^/library/", regex: true },
+      ]),
+    ).resolves.toEqual(["/library/id"]);
+  });
+
   it("does not treat awk regexes as paths", async () => {
     const cwd = "/repo";
     vol.fromJSON({ "/repo/test.txt": "aaa" });

--- a/extensions/path-access/targets.ts
+++ b/extensions/path-access/targets.ts
@@ -1,10 +1,12 @@
 import { resolveFromCwd } from "../../src/core/paths";
+import type { IgnoredBashArgRule } from "../../src/shared/config";
 import { extractBashPathCandidates } from "../../src/shared/paths";
 
 export async function targetsForTool(
   toolName: string,
   input: Record<string, unknown>,
   cwd: string,
+  ignoredBashArgs: IgnoredBashArgRule[] = [],
 ): Promise<string[]> {
   if (["read", "write", "edit", "grep", "find", "ls"].includes(toolName)) {
     const raw = String(input.file_path ?? input.path ?? "").trim();
@@ -12,7 +14,11 @@ export async function targetsForTool(
   }
 
   if (toolName === "bash") {
-    return extractBashPathCandidates(String(input.command ?? ""), cwd);
+    return extractBashPathCandidates(
+      String(input.command ?? ""),
+      cwd,
+      ignoredBashArgs,
+    );
   }
 
   return [];

--- a/schema.json
+++ b/schema.json
@@ -176,12 +176,51 @@
       },
       "type": "object"
     },
+    "IgnoredBashArgRule": {
+      "additionalProperties": false,
+      "properties": {
+        "argPattern": {
+          "description": "Pattern matched against the individual argv token.",
+          "type": "string"
+        },
+        "command": {
+          "description": "Basename of the shell command whose argv should be checked.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for settings/schema readers.",
+          "type": "string"
+        },
+        "regex": {
+          "description": "When true, argPattern is treated as a regular expression. Default: substring match.",
+          "type": "boolean"
+        },
+        "subcommands": {
+          "description": "Optional leading argv tokens required before this rule applies.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "command",
+        "argPattern"
+      ],
+      "type": "object"
+    },
     "PathAccessConfig": {
       "additionalProperties": false,
       "properties": {
         "allowedPaths": {
           "items": {
             "type": "string"
+          },
+          "type": "array"
+        },
+        "ignoredBashArgs": {
+          "items": {
+            "$ref": "#/definitions/IgnoredBashArgRule"
           },
           "type": "array"
         },

--- a/src/shared/config/defaults.ts
+++ b/src/shared/config/defaults.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
   pathAccess: {
     mode: "ask",
     allowedPaths: [],
+    ignoredBashArgs: [],
   },
   policies: {
     rules: [

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -8,6 +8,7 @@ export {
 export type {
   DangerousPattern,
   GuardrailsConfig,
+  IgnoredBashArgRule,
   PathAccessConfig,
   PathAccessMode,
   PatternConfig,

--- a/src/shared/config/loader.ts
+++ b/src/shared/config/loader.ts
@@ -2,7 +2,12 @@ import { buildSchemaUrl, ConfigLoader } from "@aliou/pi-utils-settings";
 import pkg from "../../../package.json" with { type: "json" };
 import { DEFAULT_CONFIG } from "./defaults";
 import { migrations } from "./migration";
-import type { GuardrailsConfig, PolicyRule, ResolvedConfig } from "./types";
+import type {
+  GuardrailsConfig,
+  IgnoredBashArgRule,
+  PolicyRule,
+  ResolvedConfig,
+} from "./types";
 
 export const configLoader = new ConfigLoader<GuardrailsConfig, ResolvedConfig>(
   "guardrails",
@@ -57,6 +62,22 @@ export const configLoader = new ConfigLoader<GuardrailsConfig, ResolvedConfig>(
         }
       }
       resolved.pathAccess.allowedPaths = [...mergedPaths];
+
+      const ignoredBashArgs = new Map<string, IgnoredBashArgRule>();
+      for (const rules of [
+        global?.pathAccess?.ignoredBashArgs,
+        local?.pathAccess?.ignoredBashArgs,
+        memory?.pathAccess?.ignoredBashArgs,
+      ]) {
+        for (const rule of rules ?? []) {
+          const command = String(rule.command ?? "").trim();
+          const argPattern = String(rule.argPattern ?? "").trim();
+          if (!command || !argPattern) continue;
+          const normalized = { ...rule, command, argPattern };
+          ignoredBashArgs.set(JSON.stringify(normalized), normalized);
+        }
+      }
+      resolved.pathAccess.ignoredBashArgs = [...ignoredBashArgs.values()];
 
       return resolved;
     },

--- a/src/shared/config/types.ts
+++ b/src/shared/config/types.ts
@@ -58,9 +58,23 @@ export interface PolicyRule {
 
 export type PathAccessMode = "allow" | "ask" | "block";
 
+export interface IgnoredBashArgRule {
+  /** Basename of the shell command whose argv should be checked. */
+  command: string;
+  /** Optional leading argv tokens required before this rule applies. */
+  subcommands?: string[];
+  /** Pattern matched against the individual argv token. */
+  argPattern: string;
+  /** Optional description for settings/schema readers. */
+  description?: string;
+  /** When true, argPattern is treated as a regular expression. Default: substring match. */
+  regex?: boolean;
+}
+
 export interface PathAccessConfig {
   mode?: PathAccessMode;
   allowedPaths?: string[];
+  ignoredBashArgs?: IgnoredBashArgRule[];
 }
 
 export interface GuardrailsConfig {
@@ -128,6 +142,7 @@ export interface ResolvedConfig {
   pathAccess: {
     mode: PathAccessMode;
     allowedPaths: string[];
+    ignoredBashArgs: IgnoredBashArgRule[];
   };
   permissionGate: {
     patterns: DangerousPattern[];

--- a/src/shared/paths/bash-paths.test.ts
+++ b/src/shared/paths/bash-paths.test.ts
@@ -6,6 +6,57 @@ const CWD = "/work/project";
 const HOME = homedir();
 
 describe("extractBashPathCandidates", () => {
+  it("does not extract configured ignored bash args", async () => {
+    const result = await extractBashPathCandidates(
+      "tool docs /library/id ./file",
+      CWD,
+      [
+        {
+          command: "tool",
+          subcommands: ["docs"],
+          argPattern: "^/library/",
+          regex: true,
+        },
+      ],
+    );
+
+    expect(result).toEqual(["/work/project/file"]);
+  });
+
+  it("keeps ignored bash args scoped to matching subcommands", async () => {
+    const result = await extractBashPathCandidates(
+      "tool read /library/id ./file",
+      CWD,
+      [
+        {
+          command: "tool",
+          subcommands: ["docs"],
+          argPattern: "^/library/",
+          regex: true,
+        },
+      ],
+    );
+
+    expect(result).toEqual(["/library/id", "/work/project/file"]);
+  });
+
+  it("does not apply ignored bash args to redirects", async () => {
+    const result = await extractBashPathCandidates(
+      "tool docs /library/id > /library/out",
+      CWD,
+      [
+        {
+          command: "tool",
+          subcommands: ["docs"],
+          argPattern: "^/library/",
+          regex: true,
+        },
+      ],
+    );
+
+    expect(result).toEqual(["/library/out"]);
+  });
+
   it("does not extract go package wildcard patterns as paths", async () => {
     const result = await extractBashPathCandidates("go test ./...", CWD);
 

--- a/src/shared/paths/bash-paths.ts
+++ b/src/shared/paths/bash-paths.ts
@@ -3,7 +3,43 @@ import { parse } from "@aliou/sh";
 import { expandHomePath, maybePathLike } from "../../core/paths/path";
 import { walkCommands, wordToString } from "../../core/shell/ast";
 import { classifyCommandArgs } from "../../core/shell/command-args";
+import type { IgnoredBashArgRule } from "../config/types";
 import { expandGlob, hasGlobChars } from "../glob";
+
+function basenameOfCommand(command: string): string {
+  const value = String(command);
+  return value.split(/[\\/]/).pop()?.toLowerCase() ?? value.toLowerCase();
+}
+
+function matchesArgPattern(rule: IgnoredBashArgRule, token: string): boolean {
+  if (rule.regex) {
+    try {
+      return new RegExp(rule.argPattern).test(token);
+    } catch {
+      return false;
+    }
+  }
+
+  return token.includes(rule.argPattern);
+}
+
+function shouldIgnoreBashArg(
+  command: string,
+  args: string[],
+  token: string,
+  ignoredArgs: IgnoredBashArgRule[],
+): boolean {
+  const commandName = basenameOfCommand(command);
+  return ignoredArgs.some((rule) => {
+    if (basenameOfCommand(rule.command) !== commandName) return false;
+    if (rule.subcommands) {
+      for (let i = 0; i < rule.subcommands.length; i++) {
+        if (args[i] !== rule.subcommands[i]) return false;
+      }
+    }
+    return matchesArgPattern(rule, token);
+  });
+}
 
 async function expandCandidate(
   candidate: string,
@@ -22,6 +58,7 @@ async function expandCandidate(
 export async function extractBashPathCandidates(
   command: string,
   cwd: string,
+  ignoredArgs: IgnoredBashArgRule[] = [],
 ): Promise<string[]> {
   const seen = new Set<string>();
   const results: string[] = [];
@@ -50,8 +87,12 @@ export async function extractBashPathCandidates(
     walkCommands(ast, (cmd) => {
       const words = (cmd.words ?? []).map(wordToString);
       const commandName = words[0];
+      const args = words.slice(1);
       if (commandName) {
-        for (const arg of classifyCommandArgs(commandName, words.slice(1))) {
+        for (const arg of classifyCommandArgs(commandName, args)) {
+          if (shouldIgnoreBashArg(commandName, args, arg.token, ignoredArgs)) {
+            continue;
+          }
           pending.push(addCandidate(arg.token, arg.forcePath));
         }
       }
@@ -64,7 +105,8 @@ export async function extractBashPathCandidates(
     await Promise.all(pending);
     return results;
   } catch {
-    // Fallback: regex tokenization
+    // Fallback: regex tokenization. Configured ignored bash args require
+    // parsed command argv context, so fallback stays conservative.
     const tokenRegex = /"([^"]+)"|'([^']+)'|`([^`]+)`|([^\s"'`<>|;&]+)/g;
     for (const match of command.matchAll(tokenRegex)) {
       const token = match[1] ?? match[2] ?? match[3] ?? match[4] ?? "";


### PR DESCRIPTION
## Summary

Implements #50. Related concrete use case: #49. This is independent from the narrower ctx7 classifier fix in #51.

Adds an advanced `pathAccess.ignoredBashArgs` config escape hatch for command-scoped bash argv tokens that look like filesystem paths but are actually CLI identifiers.

Example:

```jsonc
{
  "pathAccess": {
    "ignoredBashArgs": [
      {
        "command": "tool",
        "subcommands": ["docs"],
        "argPattern": "^/library/",
        "regex": true,
        "description": "Slash-prefixed docs IDs are not filesystem paths"
      }
    ]
  }
}
```

## Safety boundaries

- Rules are scoped to a command basename.
- Optional `subcommands` must match leading argv tokens before a rule applies.
- Rules only filter parsed bash argv candidates.
- Redirect targets are still checked.
- Direct file tools (`read`, `write`, `edit`, `grep`, `find`, `ls`) are unaffected.
- Malformed-command fallback tokenization stays conservative and does not apply ignored-arg rules because it lacks reliable parsed argv context.

## Changes

- Add `IgnoredBashArgRule` / `pathAccess.ignoredBashArgs` to config types, defaults, merge normalization, and generated schema.
- Thread ignored bash arg rules into path-access bash target extraction.
- Add tests for:
  - positive ignored argv filtering
  - subcommand scoping
  - redirects remaining protected
  - direct file tools remaining unaffected
- Add README note and minor changeset.

## Validation

- `npx --yes pnpm@10.26.1 test`
- `npx --yes pnpm@10.26.1 typecheck`
- `npx --yes pnpm@10.26.1 lint`
- `npx --yes pnpm@10.26.1 check:schema`
