### PR TITLE
fix(examples): use regex for git force-push to catch flag at any position

### DIFF
--- a/.changeset/fix-force-push-example-regex.md
+++ b/.changeset/fix-force-push-example-regex.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Use regex for git force-push example to catch the flag at any position.

--- a/extensions/guardrails/commands/settings/examples.ts
+++ b/extensions/guardrails/commands/settings/examples.ts
@@ -198,8 +198,14 @@ export const COMMAND_EXAMPLES: Array<{
   },
   {
     label: "git push --force",
-    description: "Prompts before force-pushing Git history.",
-    pattern: { pattern: "git push --force", description: "Git force push" },
+    description:
+      "Prompts before force-pushing Git history. Uses regex so the flag is caught regardless of its position in the command (e.g. `git push origin main --force` or `-f` at the end).",
+    pattern: {
+      pattern: "git push .*(-f\\b|--force(?!-with-lease)|--force-with-lease)",
+      regex: true,
+      description:
+        "Git force push (any variant: --force, --force-with-lease, -f)",
+    },
   },
   {
     label: "npm publish",


### PR DESCRIPTION
## Problem

The existing `git push --force` example uses a literal substring match, which only fires when the flag appears immediately after `git push`:

```jsonc
{ "pattern": "git push --force", "description": "Git force push" }
```

This means the following all **bypass the guardrail**:

```sh
git push origin main --force          # flag after remote/branch
git push origin main --force-with-lease
git push origin main -f               # short flag
```

This was discovered in practice: an agent accidentally slipped a force push through by reordering the flags.

## Fix

Replace the literal pattern with a single regex that catches all three variants regardless of position:

```ts
{
  pattern: "git push .*(-f\\b|--force(?!-with-lease)|--force-with-lease)",
  regex: true,
  description: "Git force push (any variant: --force, --force-with-lease, -f)",
}
```

- `-f\b` — short flag, word-boundary-terminated so it won't match `--config` etc.
- `--force(?!-with-lease)` — matches `--force` alone via negative lookahead
- `--force-with-lease` — matched explicitly
- `.*` between `git push` and the flag group — covers remote, branch, and any other args in between

The description is also updated to document why regex is used, as a useful reference for users building their own patterns.