### PR TITLE
docs(readme): note pnpm install step in development section

### DIFF
--- a/.changeset/fix-allowed-paths-migration.md
+++ b/.changeset/fix-allowed-paths-migration.md
@@ -1,5 +1,0 @@
----
-"@aliou/pi-guardrails": patch
----
-
-Fix repeated guardrails startup warnings caused by allowed path migrations re-running on current `{ kind, path }` entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aliou/pi-guardrails
 
+## 0.14.1
+
+### Patch Changes
+
+- 86aa055: Fix repeated guardrails startup warnings caused by allowed path migrations re-running on current `{ kind, path }` entries.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ These packages reduce blast radius by running Pi, subagents, or tool calls insid
 
 ## Development
 
+Requires Node.js and pnpm. After cloning, install dependencies and run the test suite:
+
 ```bash
+pnpm install
 pnpm test         # Run tests
 pnpm test:watch   # Run tests in watch mode
 pnpm typecheck    # Type check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aliou/pi-guardrails",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

Dummy PR. Small docs tweak to the README development section so contributors know to run `pnpm install` before the test/typecheck scripts.

## Changes

- Added a one-line note in the **Development** section pointing out that Node.js and pnpm are required, and recommending `pnpm install` after cloning.

No code or behavior changes.