### PR TITLE
feat(permission-gate): decline and stop option

### DIFF
--- a/.changeset/permission-gate-decline-and-stop.md
+++ b/.changeset/permission-gate-decline-and-stop.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add a "decline and stop" option to the permission-gate prompt. Choosing it (press `s`, or select "Decline and stop" in the RPC fallback) blocks the dangerous command, emits a `guardrails:action:blocked` event with the new `user-stop` block source, and aborts the current agent turn so the assistant does not keep going.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Granted paths are stored in `pathAccess.allowedPaths` as explicit `{ kind, path 
 
 The `permission-gate` extension detects dangerous bash commands before they run.
 
-It catches built-in risky patterns like recursive deletes, privileged commands, disk formatting, broad permission changes, and configured custom patterns. You can allow once, allow for the session, deny, or configure auto-deny rules.
+It catches built-in risky patterns like recursive deletes, privileged commands, disk formatting, broad permission changes, and configured custom patterns. You can allow once, allow for the session, deny, decline and stop (which also aborts the current turn), or configure auto-deny rules.
 
 [![Guardrails permission gate walkthrough](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.gif)](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.mp4)
 

--- a/extensions/permission-gate/index.test.ts
+++ b/extensions/permission-gate/index.test.ts
@@ -1,4 +1,19 @@
+import type {
+  BashToolCallEvent,
+  ExtensionAPI,
+  ExtensionContext,
+  ExtensionHandler,
+  ReadToolCallEvent,
+  ToolCallEvent,
+  ToolCallEventResult,
+} from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
+import {
+  GUARDRAILS_ACTION_BLOCKED_EVENT,
+  GUARDRAILS_FEATURE_REGISTER_EVENT,
+  GUARDRAILS_FEATURE_REQUEST_EVENT,
+} from "../../src/shared/events";
+import permissionGate from "./index";
 
 // Control the config the hook sees without touching the real config loader.
 vi.mock("../../src/shared/config", () => {
@@ -25,17 +40,7 @@ vi.mock("../../src/shared/config", () => {
   };
 });
 
-import {
-  GUARDRAILS_ACTION_BLOCKED_EVENT,
-  GUARDRAILS_FEATURE_REGISTER_EVENT,
-  GUARDRAILS_FEATURE_REQUEST_EVENT,
-} from "../../src/shared/events";
-import permissionGate from "./index";
-
-type ToolCallHandler = (
-  event: { toolName: string; input: { command: string } },
-  ctx: any,
-) => Promise<unknown>;
+type ToolCallHandler = ExtensionHandler<ToolCallEvent, ToolCallEventResult>;
 
 interface MockPi {
   events: { on: ReturnType<typeof vi.fn>; emit: ReturnType<typeof vi.fn> };
@@ -70,18 +75,18 @@ function createCtx(overrides: Record<string, unknown> = {}) {
     },
     abort: vi.fn(),
     ...overrides,
-  };
+  } as unknown as ExtensionContext;
 }
 
 const DANGEROUS_EVENT = {
   toolName: "bash",
   input: { command: "dangerous-cmd" },
-};
+} as unknown as BashToolCallEvent;
 
 describe("permissionGate extension hook", () => {
   it("registers the permissionGate feature on request", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const onCalls = pi.events.on.mock.calls;
     const requestHandler = onCalls.find(
@@ -100,10 +105,13 @@ describe("permissionGate extension hook", () => {
 
   it("returns undefined for safe commands", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const result = await pi.callHook(
-      { toolName: "bash", input: { command: "echo hello" } },
+      {
+        toolName: "bash",
+        input: { command: "echo hello" },
+      } as BashToolCallEvent,
       createCtx(),
     );
     expect(result).toBeUndefined();
@@ -111,10 +119,13 @@ describe("permissionGate extension hook", () => {
 
   it("returns undefined for non-bash tools", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const result = await pi.callHook(
-      { toolName: "read", input: { command: "dangerous-cmd" } },
+      {
+        toolName: "read",
+        input: { command: "dangerous-cmd" },
+      } as unknown as ReadToolCallEvent,
       createCtx(),
     );
     expect(result).toBeUndefined();
@@ -122,7 +133,7 @@ describe("permissionGate extension hook", () => {
 
   it("deny returns { block: true } without aborting the turn", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const ctx = createCtx({
       ui: { custom: vi.fn().mockResolvedValue("deny"), select: vi.fn() },
@@ -145,7 +156,7 @@ describe("permissionGate extension hook", () => {
 
   it("stop calls ctx.abort() and returns { block: true } with user-stop source", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const ctx = createCtx({
       ui: { custom: vi.fn().mockResolvedValue("stop"), select: vi.fn() },
@@ -168,7 +179,7 @@ describe("permissionGate extension hook", () => {
 
   it("allow once returns undefined and does not abort", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const ctx = createCtx({
       ui: { custom: vi.fn().mockResolvedValue("allow"), select: vi.fn() },
@@ -181,7 +192,7 @@ describe("permissionGate extension hook", () => {
 
   it("RPC fallback exposes 'Decline and stop' and maps it to stop", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const select = vi.fn().mockResolvedValue("Decline and stop");
     const ctx = createCtx({
@@ -208,7 +219,7 @@ describe("permissionGate extension hook", () => {
 
   it("non-interactive (no UI) blocks with nonInteractive source and does not abort", async () => {
     const pi = createPi();
-    await permissionGate(pi as any);
+    await permissionGate(pi as unknown as ExtensionAPI);
 
     const ctx = createCtx({ hasUI: false });
     const result = await pi.callHook(DANGEROUS_EVENT, ctx);

--- a/extensions/permission-gate/index.test.ts
+++ b/extensions/permission-gate/index.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Control the config the hook sees without touching the real config loader.
+vi.mock("../../src/shared/config", () => {
+  function makeConfig(overrides: Record<string, unknown> = {}) {
+    return {
+      enabled: true,
+      features: { permissionGate: true, policies: true, pathAccess: true },
+      permissionGate: {
+        patterns: [{ pattern: "dangerous-cmd", description: "test danger" }],
+        useBuiltinMatchers: false,
+        requireConfirmation: true,
+        allowedPatterns: [],
+        autoDenyPatterns: [],
+        ...overrides,
+      },
+    };
+  }
+
+  return {
+    configLoader: {
+      load: vi.fn().mockResolvedValue(undefined),
+      getConfig: vi.fn(() => makeConfig()),
+    },
+  };
+});
+
+import {
+  GUARDRAILS_ACTION_BLOCKED_EVENT,
+  GUARDRAILS_FEATURE_REGISTER_EVENT,
+  GUARDRAILS_FEATURE_REQUEST_EVENT,
+} from "../../src/shared/events";
+import permissionGate from "./index";
+
+type ToolCallHandler = (
+  event: { toolName: string; input: { command: string } },
+  ctx: any,
+) => Promise<unknown>;
+
+interface MockPi {
+  events: { on: ReturnType<typeof vi.fn>; emit: ReturnType<typeof vi.fn> };
+  on: ReturnType<typeof vi.fn>;
+}
+
+function createPi(): MockPi & { callHook: ToolCallHandler } {
+  let hook: ToolCallHandler | undefined;
+  const pi: MockPi = {
+    events: { on: vi.fn(), emit: vi.fn() },
+    on: vi.fn((event: string, handler: ToolCallHandler) => {
+      if (event === "tool_call") hook = handler;
+    }),
+  };
+  return {
+    ...pi,
+    callHook: (...args) => {
+      if (!hook) throw new Error("tool_call hook not registered");
+      return hook(...args);
+    },
+  };
+}
+
+function createCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    hasUI: true,
+    mode: "tui",
+    ui: {
+      custom: vi.fn().mockResolvedValue(undefined),
+      select: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn(),
+    },
+    abort: vi.fn(),
+    ...overrides,
+  };
+}
+
+const DANGEROUS_EVENT = {
+  toolName: "bash",
+  input: { command: "dangerous-cmd" },
+};
+
+describe("permissionGate extension hook", () => {
+  it("registers the permissionGate feature on request", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const onCalls = pi.events.on.mock.calls;
+    const requestHandler = onCalls.find(
+      ([event]) => event === GUARDRAILS_FEATURE_REQUEST_EVENT,
+    )?.[1] as ((...args: unknown[]) => void) | undefined;
+
+    expect(requestHandler).toBeDefined();
+    requestHandler?.();
+    expect(pi.events.emit).toHaveBeenCalledWith(
+      GUARDRAILS_FEATURE_REGISTER_EVENT,
+      expect.objectContaining({
+        feature: { id: "permissionGate" },
+      }),
+    );
+  });
+
+  it("returns undefined for safe commands", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const result = await pi.callHook(
+      { toolName: "bash", input: { command: "echo hello" } },
+      createCtx(),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for non-bash tools", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const result = await pi.callHook(
+      { toolName: "read", input: { command: "dangerous-cmd" } },
+      createCtx(),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("deny returns { block: true } without aborting the turn", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const ctx = createCtx({
+      ui: { custom: vi.fn().mockResolvedValue("deny"), select: vi.fn() },
+    });
+
+    const result = await pi.callHook(DANGEROUS_EVENT, ctx);
+
+    expect(result).toEqual({
+      block: true,
+      reason: "User denied dangerous command",
+    });
+    expect(ctx.abort).not.toHaveBeenCalled();
+    expect(pi.events.emit).toHaveBeenCalledWith(
+      GUARDRAILS_ACTION_BLOCKED_EVENT,
+      expect.objectContaining({
+        block: expect.objectContaining({ source: "user" }),
+      }),
+    );
+  });
+
+  it("stop calls ctx.abort() and returns { block: true } with user-stop source", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const ctx = createCtx({
+      ui: { custom: vi.fn().mockResolvedValue("stop"), select: vi.fn() },
+    });
+
+    const result = await pi.callHook(DANGEROUS_EVENT, ctx);
+
+    expect(result).toEqual({
+      block: true,
+      reason: "User declined and stopped dangerous command",
+    });
+    expect(ctx.abort).toHaveBeenCalledTimes(1);
+    expect(pi.events.emit).toHaveBeenCalledWith(
+      GUARDRAILS_ACTION_BLOCKED_EVENT,
+      expect.objectContaining({
+        block: expect.objectContaining({ source: "user-stop" }),
+      }),
+    );
+  });
+
+  it("allow once returns undefined and does not abort", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const ctx = createCtx({
+      ui: { custom: vi.fn().mockResolvedValue("allow"), select: vi.fn() },
+    });
+
+    const result = await pi.callHook(DANGEROUS_EVENT, ctx);
+    expect(result).toBeUndefined();
+    expect(ctx.abort).not.toHaveBeenCalled();
+  });
+
+  it("RPC fallback exposes 'Decline and stop' and maps it to stop", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const select = vi.fn().mockResolvedValue("Decline and stop");
+    const ctx = createCtx({
+      ui: { custom: vi.fn().mockResolvedValue(undefined), select },
+    });
+
+    const result = await pi.callHook(DANGEROUS_EVENT, ctx);
+
+    expect(select).toHaveBeenCalledWith(
+      expect.stringContaining("test danger"),
+      expect.arrayContaining([
+        "Allow once",
+        "Allow for session",
+        "Deny",
+        "Decline and stop",
+      ]),
+    );
+    expect(result).toEqual({
+      block: true,
+      reason: "User declined and stopped dangerous command",
+    });
+    expect(ctx.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-interactive (no UI) blocks with nonInteractive source and does not abort", async () => {
+    const pi = createPi();
+    await permissionGate(pi as any);
+
+    const ctx = createCtx({ hasUI: false });
+    const result = await pi.callHook(DANGEROUS_EVENT, ctx);
+
+    expect(result).toEqual({
+      block: true,
+      reason: expect.stringContaining("no UI to confirm"),
+    });
+    expect(ctx.abort).not.toHaveBeenCalled();
+    expect(pi.events.emit).toHaveBeenCalledWith(
+      GUARDRAILS_ACTION_BLOCKED_EVENT,
+      expect.objectContaining({
+        block: expect.objectContaining({ source: "nonInteractive" }),
+      }),
+    );
+  });
+});

--- a/extensions/permission-gate/index.ts
+++ b/extensions/permission-gate/index.ts
@@ -89,7 +89,7 @@ export default async function permissionGate(pi: ExtensionAPI) {
       return { block: true, reason };
     }
 
-    type ConfirmResult = "allow" | "allow-session" | "deny";
+    type ConfirmResult = "allow" | "allow-session" | "deny" | "stop";
     emitActionPrompted(pi, {
       feature: "permissionGate",
       action: safety.action,
@@ -108,10 +108,11 @@ export default async function permissionGate(pi: ExtensionAPI) {
     if (result === undefined) {
       const selection = await ctx.ui.select(
         `Dangerous command: ${safety.reason}`,
-        ["Allow once", "Allow for session", "Deny"],
+        ["Allow once", "Allow for session", "Deny", "Decline and stop"],
       );
       if (selection === "Allow once") result = "allow";
       else if (selection === "Allow for session") result = "allow-session";
+      else if (selection === "Decline and stop") result = "stop";
       else result = "deny";
     }
 
@@ -119,6 +120,19 @@ export default async function permissionGate(pi: ExtensionAPI) {
     if (result === "allow-session") {
       await saveCommandSessionGrant(command);
       return;
+    }
+
+    if (result === "stop") {
+      const reason = "User declined and stopped dangerous command";
+      emitActionBlocked(pi, {
+        feature: "permissionGate",
+        action: safety.action,
+        reason,
+        block: { source: "user-stop", metadata: safety.metadata },
+        context: { toolName: "bash", input: event.input },
+      });
+      ctx.abort();
+      return { block: true, reason };
     }
 
     const reason = "User denied dangerous command";

--- a/extensions/permission-gate/prompt.test.ts
+++ b/extensions/permission-gate/prompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { NOOP_THEME } from "../../tests/utils/theme";
+import { createPermissionGateConfirmComponent } from "./prompt";
+
+type ConfirmResult = "allow" | "allow-session" | "deny" | "stop";
+
+function mount(command: string, description = "recursive delete") {
+  let captured: ConfirmResult | undefined;
+  const done = (result: ConfirmResult) => {
+    captured = result;
+  };
+
+  const tui = {
+    terminal: { rows: 40, columns: 80 },
+    requestRender: vi.fn(),
+  };
+
+  const component = createPermissionGateConfirmComponent(command, description)(
+    tui,
+    NOOP_THEME,
+    {},
+    done,
+  );
+
+  return {
+    component,
+    result: () => captured,
+  };
+}
+
+describe("createPermissionGateConfirmComponent", () => {
+  it("renders without throwing", () => {
+    const { component } = mount("rm -rf /");
+    expect(() => component.render(80)).not.toThrow();
+  });
+
+  it("allows with y / enter keys", () => {
+    for (const key of ["y", "Y", "\r"]) {
+      const { component, result } = mount("rm -rf /");
+      component.handleInput(key);
+      expect(result()).toBe("allow");
+    }
+  });
+
+  it("grants session with a", () => {
+    const { component, result } = mount("rm -rf /");
+    component.handleInput("a");
+    expect(result()).toBe("allow-session");
+  });
+
+  it("denies with n / esc", () => {
+    const { component, result } = mount("rm -rf /");
+    component.handleInput("n");
+    expect(result()).toBe("deny");
+  });
+
+  it("emits stop when s is pressed", () => {
+    const { component, result } = mount("rm -rf /");
+    component.handleInput("s");
+    expect(result()).toBe("stop");
+  });
+
+  it("emits stop when S is pressed", () => {
+    const { component, result } = mount("rm -rf /");
+    component.handleInput("S");
+    expect(result()).toBe("stop");
+  });
+
+  it("does nothing for unrelated keys", () => {
+    const { component, result } = mount("rm -rf /");
+    component.handleInput("x");
+    expect(result()).toBeUndefined();
+  });
+
+  it("rendered footer contains the stop hint", () => {
+    const { component } = mount("rm -rf /");
+    const rendered = component.render(80);
+    const output = Array.isArray(rendered)
+      ? rendered.join("\n")
+      : String(rendered);
+    expect(output).toContain("s: decline &");
+    expect(output).toContain("stop");
+    expect(output).toContain("n/esc: deny");
+  });
+});

--- a/extensions/permission-gate/prompt.ts
+++ b/extensions/permission-gate/prompt.ts
@@ -103,7 +103,7 @@ export function createPermissionGateConfirmComponent(
     tui: { terminal: { rows: number; columns: number }; requestRender(): void },
     theme: MinimalTheme,
     _kb: unknown,
-    done: (result: "allow" | "allow-session" | "deny") => void,
+    done: (result: "allow" | "allow-session" | "deny" | "stop") => void,
   ) => {
     const container = new Container();
     const redBorder = (s: string) => theme.fg("error", s);
@@ -140,7 +140,7 @@ export function createPermissionGateConfirmComponent(
       new Text(
         theme.fg(
           "dim",
-          "↑/↓ or j/k: scroll • y/enter: allow • a: session • n/esc: deny",
+          "↑/↓ or j/k: scroll • y/enter: allow • a: session • n/esc: deny • s: decline & stop",
         ),
         1,
         0,
@@ -215,6 +215,8 @@ export function createPermissionGateConfirmComponent(
           data === "N"
         ) {
           done("deny");
+        } else if (data === "s" || data === "S") {
+          done("stop");
         }
       },
     };

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -32,6 +32,7 @@ export type GuardrailsBlockSource =
   | "policy"
   | "permission"
   | "user"
+  | "user-stop"
   | "nonInteractive";
 
 export type GuardrailsActionBlockedPayload<TMeta = unknown> =


### PR DESCRIPTION
Implements #62 + does some cleanup around tests and the agents.md

------

<details><summary>Summary by GLM-5.2 Short:</summary>
<p>

## Summary

Adds a "decline and stop" option to the permission-gate prompt. Choosing it blocks the dangerous command **and** aborts the current agent turn, so the assistant does not keep going after a rejected dangerous command.

## How it works

- Press `s` in the TUI confirm prompt, or select **"Decline and stop"** in the RPC/non-TUI fallback.
- Emits `guardrails:action:blocked` with the new `user-stop` block source (distinguishes from a plain `deny`).
- Calls `ctx.abort()` to stop the current turn.
- Returns `{ block: true, reason }` so the bash tool does not execute.

Plain `deny` (n/esc) behavior is unchanged: it blocks but lets the turn continue.

## Files changed

- `src/shared/events.ts` — added `"user-stop"` to `GuardrailsBlockSource`.
- `extensions/permission-gate/prompt.ts` — expanded `ConfirmResult` to include `"stop"`, handle `s`/`S`, updated footer hint to `s: decline & stop`.
- `extensions/permission-gate/index.ts` — added `"Decline and stop"` to the `ctx.ui.select` RPC fallback; on `"stop"` emit blocked event with `user-stop`, call `ctx.abort()`, return `{ block: true }`.
- `README.md` — describe the new option.

## Tests

- `extensions/permission-gate/prompt.test.ts` — `s`/`S` emit `"stop"`; `y`/`enter`/`a`/`n`/`esc` still backward compatible; footer hint present.
- `extensions/permission-gate/index.test.ts` — deny returns `{ block: true }` without aborting (source `user`); stop calls `ctx.abort()` once and returns `{ block: true }` (source `user-stop`); RPC fallback exposes "Decline and stop"; allow once returns undefined; non-interactive blocks with `nonInteractive` source.

Checks: typecheck clean, 278 tests pass, lint clean, schema in sync.

## Changeset

`minor` — new user-facing feature.

</p>
</details>