### PR TITLE
chore: use changelog entry as GitHub release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,10 +110,16 @@ jobs:
         if: steps.check-publish.outputs.needs_staging == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.check-publish.outputs.version }}
         run: |
-          TAG="v${{ steps.check-publish.outputs.version }}"
+          TAG="v$VERSION"
           git tag "$TAG"
           git push origin "$TAG"
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --title "$TAG" --notes "Release $TAG"
+            awk -v v="$VERSION" '
+              $0 == "## " v { found=1; next }
+              found && /^## / { exit }
+              found { print }
+            ' CHANGELOG.md > /tmp/release-notes.md
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/release-notes.md
           fi

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
       "./extensions/guardrails/index.ts",
       "./extensions/permission-gate/index.ts"
     ],
-    "video": "https://assets.aliou.me/github/aliou/pi-guardrails/demo.mp4"
+    "video": "https://assets.aliou.me/github/aliou/pi-guardrails/demo.mp4",
+    "image": "https://assets.aliou.me/github/aliou/pi-guardrails/banner.png"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Use the version's changelog section from `CHANGELOG.md` as the GitHub release notes instead of the generic `Release vX.Y.Z` placeholder.

The publish workflow now extracts the `## <version>` section from `CHANGELOG.md` and passes it to `gh release create --notes-file`.

Existing `vX.Y.Z` releases have also been backfilled with their changelog content (legacy `package@version` releases left untouched).
