### PR TITLE
Show Guardrails approval prompts as waiting in Herdr

### DIFF
--- a/.changeset/calm-pandas-resolve.md
+++ b/.changeset/calm-pandas-resolve.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add a `guardrails:action:prompt-resolved` event that pairs with `guardrails:action:prompted`, allowing status integrations to detect when Guardrails no longer needs human input.

--- a/.changeset/calm-pandas-resolve.md
+++ b/.changeset/calm-pandas-resolve.md
@@ -2,4 +2,4 @@
 "@aliou/pi-guardrails": minor
 ---
 
-Add a `guardrails:action:prompt-resolved` event that pairs with `guardrails:action:prompted`, allowing status integrations to detect when Guardrails no longer needs human input.
+Add a `guardrails:action:prompt-resolved` event that pairs with `guardrails:action:prompted`, allowing status integrations to detect when Guardrails no longer needs human input. Include an optional Herdr adapter that uses the lifecycle pair to show approval prompts as blocked in Herdr's Agents overview.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Each extension owns one Pi `tool_call` hook. Instead of a single guardrails hook
 - Config migrations are predicate-based (`shouldRun`) using structural checks; do not rely on lexicographic version string comparisons.
 - Runtime code must only handle current config/core shapes. Old config shapes belong exclusively in migrations; do not add runtime compatibility branches for legacy config.
 - `config.version` is a schema marker for debugging/inspection, not the package version.
-- Events emitted on the pi event bus for inter-extension communication are defined in `src/shared/events.ts`. Current public events are `guardrails:action:blocked`, `guardrails:action:prompted`, `guardrails:risk:detected`, `guardrails:feature:request`, and `guardrails:feature:register`.
+- Events emitted on the pi event bus for inter-extension communication are defined in `src/shared/events.ts`. Current public events are `guardrails:action:blocked`, `guardrails:action:prompted`, `guardrails:action:prompt-resolved`, `guardrails:risk:detected`, `guardrails:feature:request`, and `guardrails:feature:register`.
 
 ## Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,12 +64,14 @@ extensions/
     prompt.ts             # Confirmation UI prompt
     rules.ts              # Permission gate rule and command matching
     index.ts              # Registers permission-gate hook and feature registration
+  herdr/                   # Optional Herdr Agents overview integration
+    index.ts               # Maps prompt lifecycle events to herdr:blocked
 tests/
   utils/                  # Test utilities (memfs setup, theme, tmpdir, vitest setup)
   vitest.setup.ts         # Global test setup
 ```
 
-Each extension owns one Pi `tool_call` hook. Instead of a single guardrails hook, the package registers three independent extensions that communicate feature presence through the Pi event bus.
+Each safety extension owns one Pi `tool_call` hook. Instead of a single guardrails hook, the package registers three independent safety extensions that communicate feature presence through the Pi event bus. A fourth extension maps prompt lifecycle events to Herdr's optional `herdr:blocked` integration event.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ It catches built-in risky patterns like recursive deletes, privileged commands, 
 
 [![Guardrails permission gate walkthrough](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.gif)](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.mp4)
 
+## Public events
+
+Guardrails extensions publish lifecycle events on Pi's shared event bus so other extensions can observe safety decisions without coupling to the prompt UI:
+
+- `guardrails:risk:detected` when an action matches a risk rule.
+- `guardrails:action:prompted` immediately before an interactive permission or path-access prompt is shown.
+- `guardrails:action:prompt-resolved` after that prompt interaction finishes, including when the prompt throws. It carries the same action, reason, prompt, and tool context as the matching prompted event.
+- `guardrails:action:blocked` when an action is blocked by policy, configuration, unavailable UI, or the user.
+- `guardrails:feature:request` and `guardrails:feature:register` for discovery between the three included extensions.
+
+Consumers can use the prompted/resolved pair to report that Pi is waiting for human input without inferring state from terminal output.
+
 ## Configuration
 
 Most configuration should happen through the interactive settings UI:

--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 
 Guardrails adds safety checks to Pi so agents are less likely to read secrets, write protected files, access paths outside the workspace, or run dangerous shell commands by accident.
 
-This package installs four Pi extensions:
+This package installs three Pi extensions:
 
 - **guardrails** for file protection policies, settings, onboarding, and examples.
 - **path-access** for controlling access outside the current workspace.
 - **permission-gate** for confirming or blocking risky shell commands.
-- **herdr** for optionally reporting approval prompts to Herdr's Agents overview.
 
 ## Install
 
@@ -68,24 +67,6 @@ The `permission-gate` extension detects dangerous bash commands before they run.
 It catches built-in risky patterns like recursive deletes, privileged commands, disk formatting, broad permission changes, and configured custom patterns. You can allow once, allow for the session, deny, decline and stop (which also aborts the current turn), or configure auto-deny rules.
 
 [![Guardrails permission gate walkthrough](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.gif)](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.mp4)
-
-### herdr
-
-The `herdr` extension translates Guardrails' prompt lifecycle into the `herdr:blocked` event understood by Herdr's official Pi integration. Herdr's Agents overview shows Pi as blocked while Guardrails needs approval and clears the state when the prompt resolves.
-
-The integration is optional and has no Herdr dependency or configuration. Without Herdr's Pi integration listening for the event, the reports are no-ops.
-
-## Public events
-
-Guardrails extensions publish lifecycle events on Pi's shared event bus so other extensions can observe safety decisions without coupling to the prompt UI:
-
-- `guardrails:risk:detected` when an action matches a risk rule.
-- `guardrails:action:prompted` immediately before an interactive permission or path-access prompt is shown.
-- `guardrails:action:prompt-resolved` after that prompt interaction finishes, including when the prompt throws. It carries the same action, reason, prompt, and tool context as the matching prompted event.
-- `guardrails:action:blocked` when an action is blocked by policy, configuration, unavailable UI, or the user.
-- `guardrails:feature:request` and `guardrails:feature:register` for discovery between the three included extensions.
-
-Consumers can use the prompted/resolved pair to report that Pi is waiting for human input without inferring state from terminal output.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 Guardrails adds safety checks to Pi so agents are less likely to read secrets, write protected files, access paths outside the workspace, or run dangerous shell commands by accident.
 
-This package installs three Pi extensions:
+This package installs four Pi extensions:
 
 - **guardrails** for file protection policies, settings, onboarding, and examples.
 - **path-access** for controlling access outside the current workspace.
 - **permission-gate** for confirming or blocking risky shell commands.
+- **herdr** for optionally reporting approval prompts to Herdr's Agents overview.
 
 ## Install
 
@@ -67,6 +68,12 @@ The `permission-gate` extension detects dangerous bash commands before they run.
 It catches built-in risky patterns like recursive deletes, privileged commands, disk formatting, broad permission changes, and configured custom patterns. You can allow once, allow for the session, deny, decline and stop (which also aborts the current turn), or configure auto-deny rules.
 
 [![Guardrails permission gate walkthrough](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.gif)](https://assets.aliou.me/github/aliou/pi-guardrails/v0.12.0/permission-gate.mp4)
+
+### herdr
+
+The `herdr` extension translates Guardrails' prompt lifecycle into the `herdr:blocked` event understood by Herdr's official Pi integration. Herdr's Agents overview shows Pi as blocked while Guardrails needs approval and clears the state when the prompt resolves.
+
+The integration is optional and has no Herdr dependency or configuration. Without Herdr's Pi integration listening for the event, the reports are no-ops.
 
 ## Public events
 

--- a/extensions/herdr/index.test.ts
+++ b/extensions/herdr/index.test.ts
@@ -1,0 +1,47 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+  GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+  GUARDRAILS_ACTION_PROMPTED_EVENT,
+} from "../../src/shared/events";
+import herdrIntegration from "./index";
+
+type EventHandler = (event: unknown) => void;
+
+function createPi() {
+  const handlers = new Map<string, EventHandler>();
+  const pi = {
+    events: {
+      on: vi.fn((event: string, handler: EventHandler) => {
+        handlers.set(event, handler);
+      }),
+      emit: vi.fn(),
+    },
+  };
+
+  herdrIntegration(pi as unknown as ExtensionAPI);
+  return { pi, handlers };
+}
+
+describe("Herdr integration", () => {
+  it("reports blocked while Guardrails is waiting for a prompt", () => {
+    const { pi, handlers } = createPi();
+
+    handlers.get(GUARDRAILS_ACTION_PROMPTED_EVENT)?.({});
+
+    expect(pi.events.emit).toHaveBeenCalledWith("herdr:blocked", {
+      active: true,
+      label: "Guardrails approval required",
+    });
+  });
+
+  it("clears blocked state after the prompt resolves", () => {
+    const { pi, handlers } = createPi();
+
+    handlers.get(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT)?.({});
+
+    expect(pi.events.emit).toHaveBeenCalledWith("herdr:blocked", {
+      active: false,
+    });
+  });
+});

--- a/extensions/herdr/index.ts
+++ b/extensions/herdr/index.ts
@@ -1,0 +1,21 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+  GUARDRAILS_ACTION_PROMPTED_EVENT,
+} from "../../src/shared/events";
+
+const HERDR_BLOCKED_EVENT = "herdr:blocked";
+const BLOCKED_LABEL = "Guardrails approval required";
+
+export default function herdrIntegration(pi: ExtensionAPI) {
+  pi.events.on(GUARDRAILS_ACTION_PROMPTED_EVENT, () => {
+    pi.events.emit(HERDR_BLOCKED_EVENT, {
+      active: true,
+      label: BLOCKED_LABEL,
+    });
+  });
+
+  pi.events.on(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT, () => {
+    pi.events.emit(HERDR_BLOCKED_EVENT, { active: false });
+  });
+}

--- a/extensions/path-access/index.test.ts
+++ b/extensions/path-access/index.test.ts
@@ -1,0 +1,99 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ExtensionHandler,
+  ReadToolCallEvent,
+  ToolCallEvent,
+  ToolCallEventResult,
+} from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { configLoader } from "../../src/shared/config";
+import {
+  GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+  GUARDRAILS_ACTION_PROMPTED_EVENT,
+} from "../../src/shared/events";
+import pathAccess from "./index";
+import { targetsForTool } from "./targets";
+
+vi.mock("../../src/shared/config", () => ({
+  configLoader: {
+    load: vi.fn().mockResolvedValue(undefined),
+    getConfig: vi.fn(() => ({
+      enabled: true,
+      features: { permissionGate: true, policies: true, pathAccess: true },
+      pathAccess: { mode: "ask", allowedPaths: [] },
+    })),
+  },
+}));
+
+vi.mock("./dynamic-resources", () => ({
+  piDocumentationPaths: vi.fn(() => []),
+}));
+vi.mock("./grants", () => ({
+  createPendingGrant: vi.fn(),
+  isGrantTooBroad: vi.fn(() => false),
+  pendingAllowedPaths: vi.fn(() => []),
+  persistGrant: vi.fn(),
+  resolveAllowedPaths: vi.fn(() => []),
+}));
+vi.mock("./targets", () => ({
+  targetsForTool: vi.fn().mockResolvedValue(["/outside/file.txt"]),
+}));
+
+type ToolCallHandler = ExtensionHandler<ToolCallEvent, ToolCallEventResult>;
+
+function createPi() {
+  let hook: ToolCallHandler | undefined;
+  const pi = {
+    events: { on: vi.fn(), emit: vi.fn() },
+    on: vi.fn((event: string, handler: ToolCallHandler) => {
+      if (event === "tool_call") hook = handler;
+    }),
+  };
+
+  return {
+    ...pi,
+    callHook: (...args: Parameters<ToolCallHandler>) => {
+      if (!hook) throw new Error("tool_call hook not registered");
+      return hook(...args);
+    },
+  };
+}
+
+function createCtx() {
+  return {
+    cwd: "/workspace",
+    hasUI: true,
+    ui: {
+      custom: vi.fn().mockResolvedValue("allow-file-once"),
+      notify: vi.fn(),
+    },
+  } as unknown as ExtensionContext;
+}
+
+const OUTSIDE_READ_EVENT = {
+  toolName: "read",
+  input: { path: "/outside/file.txt" },
+} as ReadToolCallEvent;
+
+describe("pathAccess extension hook", () => {
+  it("emits the prompt lifecycle around an outside-path approval", async () => {
+    vi.mocked(targetsForTool).mockResolvedValue(["/outside/file.txt"]);
+    const pi = createPi();
+    await pathAccess(pi as unknown as ExtensionAPI);
+
+    const ctx = createCtx();
+    const result = await pi.callHook(OUTSIDE_READ_EVENT, ctx);
+
+    expect(configLoader.getConfig).toHaveBeenCalled();
+    expect(targetsForTool).toHaveBeenCalled();
+    expect(ctx.ui.custom).toHaveBeenCalled();
+    expect(result).toBeUndefined();
+    const eventNames = pi.events.emit.mock.calls.map(([event]) => event);
+    expect(eventNames).toContain(GUARDRAILS_ACTION_PROMPTED_EVENT);
+    expect(eventNames).toContain(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT);
+    expect(eventNames.indexOf(GUARDRAILS_ACTION_PROMPTED_EVENT)).toBeLessThan(
+      eventNames.indexOf(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT),
+    );
+  });
+});

--- a/extensions/path-access/index.ts
+++ b/extensions/path-access/index.ts
@@ -10,9 +10,9 @@ import { configLoader } from "../../src/shared/config";
 import {
   createFeatureRegisterPayload,
   emitActionBlocked,
-  emitActionPrompted,
   GUARDRAILS_FEATURE_REGISTER_EVENT,
   GUARDRAILS_FEATURE_REQUEST_EVENT,
+  withActionPromptLifecycle,
 } from "../../src/shared/events";
 import { piDocumentationPaths } from "./dynamic-resources";
 import {
@@ -107,25 +107,28 @@ export default async function pathAccess(pi: ExtensionAPI) {
       const parentDir = dirname(absolutePath);
       const showFileOptions =
         event.toolName !== "ls" && event.toolName !== "find";
-      emitActionPrompted(pi, {
-        feature: "pathAccess",
-        action: safety.action,
-        reason: safety.reason,
-        prompt: {
-          kind: "confirmation",
-          metadata: safety.metadata,
+      const result = await withActionPromptLifecycle(
+        pi,
+        {
+          feature: "pathAccess",
+          action: safety.action,
+          reason: safety.reason,
+          prompt: {
+            kind: "confirmation",
+            metadata: safety.metadata,
+          },
+          context: { toolName: event.toolName, input },
         },
-        context: { toolName: event.toolName, input },
-      });
-
-      const result = await ctx.ui.custom<PromptResult>(
-        createPathAccessPromptComponent(
-          event.toolName,
-          safety.metadata.displayPath,
-          normalizeForDisplay(parentDir, ctx.cwd),
-          ctx.cwd,
-          showFileOptions,
-        ),
+        () =>
+          ctx.ui.custom<PromptResult>(
+            createPathAccessPromptComponent(
+              event.toolName,
+              safety.metadata.displayPath,
+              normalizeForDisplay(parentDir, ctx.cwd),
+              ctx.cwd,
+              showFileOptions,
+            ),
+          ),
       );
 
       if (result === "allow-file-once" || result === "allow-dir-once") {

--- a/extensions/permission-gate/index.test.ts
+++ b/extensions/permission-gate/index.test.ts
@@ -10,6 +10,8 @@ import type {
 import { describe, expect, it, vi } from "vitest";
 import {
   GUARDRAILS_ACTION_BLOCKED_EVENT,
+  GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+  GUARDRAILS_ACTION_PROMPTED_EVENT,
   GUARDRAILS_FEATURE_REGISTER_EVENT,
   GUARDRAILS_FEATURE_REQUEST_EVENT,
 } from "../../src/shared/events";
@@ -177,7 +179,7 @@ describe("permissionGate extension hook", () => {
     );
   });
 
-  it("allow once returns undefined and does not abort", async () => {
+  it("allow once returns undefined and emits the prompt lifecycle", async () => {
     const pi = createPi();
     await permissionGate(pi as unknown as ExtensionAPI);
 
@@ -188,6 +190,13 @@ describe("permissionGate extension hook", () => {
     const result = await pi.callHook(DANGEROUS_EVENT, ctx);
     expect(result).toBeUndefined();
     expect(ctx.abort).not.toHaveBeenCalled();
+
+    const eventNames = pi.events.emit.mock.calls.map(([event]) => event);
+    expect(eventNames).toContain(GUARDRAILS_ACTION_PROMPTED_EVENT);
+    expect(eventNames).toContain(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT);
+    expect(eventNames.indexOf(GUARDRAILS_ACTION_PROMPTED_EVENT)).toBeLessThan(
+      eventNames.indexOf(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT),
+    );
   });
 
   it("RPC fallback exposes 'Decline and stop' and maps it to stop", async () => {

--- a/extensions/permission-gate/index.ts
+++ b/extensions/permission-gate/index.ts
@@ -7,10 +7,10 @@ import { configLoader } from "../../src/shared/config";
 import {
   createFeatureRegisterPayload,
   emitActionBlocked,
-  emitActionPrompted,
   emitRiskDetected,
   GUARDRAILS_FEATURE_REGISTER_EVENT,
   GUARDRAILS_FEATURE_REQUEST_EVENT,
+  withActionPromptLifecycle,
 } from "../../src/shared/events";
 import { isCommandAllowed, saveCommandSessionGrant } from "./grants";
 import { createPermissionGateConfirmComponent } from "./prompt";
@@ -90,31 +90,34 @@ export default async function permissionGate(pi: ExtensionAPI) {
     }
 
     type ConfirmResult = "allow" | "allow-session" | "deny" | "stop";
-    emitActionPrompted(pi, {
-      feature: "permissionGate",
-      action: safety.action,
-      reason: safety.reason,
-      prompt: {
-        kind: "permission",
-        metadata: safety.metadata,
+    const result = await withActionPromptLifecycle<ConfirmResult>(
+      pi,
+      {
+        feature: "permissionGate",
+        action: safety.action,
+        reason: safety.reason,
+        prompt: {
+          kind: "permission",
+          metadata: safety.metadata,
+        },
+        context: { toolName: "bash", input: event.input },
       },
-      context: { toolName: "bash", input: event.input },
-    });
+      async () => {
+        const customResult = await ctx.ui.custom<ConfirmResult>(
+          createPermissionGateConfirmComponent(command, safety.reason),
+        );
+        if (customResult !== undefined) return customResult;
 
-    let result = await ctx.ui.custom<ConfirmResult>(
-      createPermissionGateConfirmComponent(command, safety.reason),
+        const selection = await ctx.ui.select(
+          `Dangerous command: ${safety.reason}`,
+          ["Allow once", "Allow for session", "Deny", "Decline and stop"],
+        );
+        if (selection === "Allow once") return "allow";
+        if (selection === "Allow for session") return "allow-session";
+        if (selection === "Decline and stop") return "stop";
+        return "deny";
+      },
     );
-
-    if (result === undefined) {
-      const selection = await ctx.ui.select(
-        `Dangerous command: ${safety.reason}`,
-        ["Allow once", "Allow for session", "Deny", "Decline and stop"],
-      );
-      if (selection === "Allow once") result = "allow";
-      else if (selection === "Allow for session") result = "allow-session";
-      else if (selection === "Decline and stop") result = "stop";
-      else result = "deny";
-    }
 
     if (result === "allow") return;
     if (result === "allow-session") {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "extensions": [
       "./extensions/path-access/index.ts",
       "./extensions/guardrails/index.ts",
-      "./extensions/permission-gate/index.ts"
+      "./extensions/permission-gate/index.ts",
+      "./extensions/herdr/index.ts"
     ],
     "video": "https://assets.aliou.me/github/aliou/pi-guardrails/demo.mp4",
     "image": "https://assets.aliou.me/github/aliou/pi-guardrails/banner.png"

--- a/src/shared/events.test.ts
+++ b/src/shared/events.test.ts
@@ -1,0 +1,72 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+  GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+  GUARDRAILS_ACTION_PROMPTED_EVENT,
+  withActionPromptLifecycle,
+} from "./events";
+
+const promptEvent = {
+  feature: "permissionGate" as const,
+  action: {
+    kind: "command" as const,
+    command: "dangerous-cmd",
+    origin: "bash",
+  },
+  reason: "test danger",
+  prompt: { kind: "permission" as const },
+  context: { toolName: "bash", input: { command: "dangerous-cmd" } },
+};
+
+function createPi() {
+  return {
+    events: { emit: vi.fn() },
+  } as unknown as ExtensionAPI;
+}
+
+describe("withActionPromptLifecycle", () => {
+  it("emits prompted before awaiting and resolved after the prompt returns", async () => {
+    const pi = createPi();
+    let resolvePrompt: ((value: "allow") => void) | undefined;
+    const prompt = new Promise<"allow">((resolve) => {
+      resolvePrompt = resolve;
+    });
+
+    const resultPromise = withActionPromptLifecycle(
+      pi,
+      promptEvent,
+      () => prompt,
+    );
+
+    expect(pi.events.emit).toHaveBeenCalledTimes(1);
+    expect(pi.events.emit).toHaveBeenNthCalledWith(
+      1,
+      GUARDRAILS_ACTION_PROMPTED_EVENT,
+      expect.objectContaining(promptEvent),
+    );
+
+    resolvePrompt?.("allow");
+    await expect(resultPromise).resolves.toBe("allow");
+
+    expect(pi.events.emit).toHaveBeenNthCalledWith(
+      2,
+      GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+      expect.objectContaining(promptEvent),
+    );
+  });
+
+  it("emits resolved when the prompt throws", async () => {
+    const pi = createPi();
+
+    await expect(
+      withActionPromptLifecycle(pi, promptEvent, async () => {
+        throw new Error("prompt failed");
+      }),
+    ).rejects.toThrow("prompt failed");
+
+    expect(pi.events.emit).toHaveBeenLastCalledWith(
+      GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT,
+      expect.objectContaining(promptEvent),
+    );
+  });
+});

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -6,6 +6,8 @@ export const GUARDRAILS_RISK_DETECTED_EVENT = "guardrails:risk:detected";
 export const GUARDRAILS_FEATURE_REQUEST_EVENT = "guardrails:feature:request";
 export const GUARDRAILS_FEATURE_REGISTER_EVENT = "guardrails:feature:register";
 export const GUARDRAILS_ACTION_PROMPTED_EVENT = "guardrails:action:prompted";
+export const GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT =
+  "guardrails:action:prompt-resolved";
 
 export type GuardrailsFeatureId = "policies" | "permissionGate" | "pathAccess";
 
@@ -64,6 +66,9 @@ export type GuardrailsActionPromptedPayload<TMeta = unknown> =
       input?: Record<string, unknown>;
     };
   };
+
+export type GuardrailsActionPromptResolvedPayload<TMeta = unknown> =
+  GuardrailsActionPromptedPayload<TMeta>;
 
 export type GuardrailsRiskDetectedPayload<TMeta = unknown> =
   GuardrailsEventBase & {
@@ -126,4 +131,31 @@ export function emitActionPrompted<TMeta = unknown>(
     timestamp: timestamp(),
     ...event,
   });
+}
+
+export function emitActionPromptResolved<TMeta = unknown>(
+  pi: ExtensionAPI,
+  event: Omit<
+    GuardrailsActionPromptResolvedPayload<TMeta>,
+    "source" | "timestamp"
+  >,
+): void {
+  pi.events.emit(GUARDRAILS_ACTION_PROMPT_RESOLVED_EVENT, {
+    source: "guardrails",
+    timestamp: timestamp(),
+    ...event,
+  });
+}
+
+export async function withActionPromptLifecycle<TResult, TMeta = unknown>(
+  pi: ExtensionAPI,
+  event: Omit<GuardrailsActionPromptedPayload<TMeta>, "source" | "timestamp">,
+  prompt: () => Promise<TResult>,
+): Promise<TResult> {
+  emitActionPrompted(pi, event);
+  try {
+    return await prompt();
+  } finally {
+    emitActionPromptResolved(pi, event);
+  }
 }


### PR DESCRIPTION
## What changed

When Guardrails asks for approval, Herdr now shows that Pi is waiting for you instead of still working.

This adds:

- A signal when the approval prompt closes.
- Support for both command and file-access prompts.
- An optional Herdr integration with no extra dependencies. Without Herdr, it simply does nothing.

## Testing

Added tests for the prompt signals and Herdr integration.

All checks pass, including 283 tests.
