### PR TITLE
feat: show command in path-access prompt

### DIFF
--- a/extensions/path-access/index.ts
+++ b/extensions/path-access/index.ts
@@ -126,6 +126,11 @@ export default async function pathAccess(pi: ExtensionAPI) {
 
       let result: PromptResult | undefined;
       try {
+        // For bash commands, use the actual command. For other tools, we can show the tool name
+        // and the prompt already shows the specific path details, so a simple representation is sufficient.
+        const commandDisplay =
+          event.toolName === "bash" ? String(input.command ?? "") : undefined;
+
         result = await ctx.ui.custom<PromptResult>(
           createPathAccessPromptComponent(
             event.toolName,
@@ -133,6 +138,7 @@ export default async function pathAccess(pi: ExtensionAPI) {
             normalizeForDisplay(parentDir, ctx.cwd),
             ctx.cwd,
             showFileOptions,
+            commandDisplay?.trim() || undefined,
           ),
         );
       } finally {

--- a/extensions/path-access/prompt.test.ts
+++ b/extensions/path-access/prompt.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createPathAccessPromptComponent } from "./prompt";
+
+describe("createPathAccessPromptComponent", () => {
+  it("should render command when provided", () => {
+    const mockTui = {
+      terminal: { columns: 80 },
+      requestRender: () => {},
+    };
+    const mockTheme = {
+      fg: (color: string, text: string) => text,
+      bg: (color: string, text: string) => text,
+      bold: (text: string) => text,
+    };
+    const mockDone = () => {};
+
+    const component = createPathAccessPromptComponent(
+      "read",
+      "/outside/file.txt",
+      "/outside",
+      "/workspace",
+      true,
+      "read /outside/file.txt",
+    );
+
+    const result = component(mockTui, mockTheme, {}, mockDone);
+    const rendered = result.render(80);
+
+    // Check that the command is included in the rendered output
+    expect(rendered.join("\n")).toContain("Command:");
+    expect(rendered.join("\n")).toContain("read /outside/file.txt");
+  });
+
+  it("should not render command section when not provided", () => {
+    const mockTui = {
+      terminal: { columns: 80 },
+      requestRender: () => {},
+    };
+    const mockTheme = {
+      fg: (color: string, text: string) => text,
+      bg: (color: string, text: string) => text,
+      bold: (text: string) => text,
+    };
+    const mockDone = () => {};
+
+    const component = createPathAccessPromptComponent(
+      "read",
+      "/outside/file.txt",
+      "/outside",
+      "/workspace",
+      true,
+      undefined,
+    );
+
+    const result = component(mockTui, mockTheme, {}, mockDone);
+    const rendered = result.render(80);
+
+    // Check that there's no command section when command is not provided
+    const fullOutput = rendered.join("\n");
+    expect(fullOutput).toContain("Outside Workspace Access");
+    expect(fullOutput).toContain("Cwd:");
+    expect(fullOutput).toContain("Path:");
+  });
+});

--- a/extensions/path-access/prompt.ts
+++ b/extensions/path-access/prompt.ts
@@ -64,6 +64,7 @@ export function createPathAccessPromptComponent(
   displayDir: string,
   cwd: string,
   showFileOptions: boolean,
+  command?: string,
 ) {
   return (
     tui: { terminal: { columns: number }; requestRender(): void },
@@ -101,6 +102,20 @@ export function createPathAccessPromptComponent(
       ),
     );
     container.addChild(new Spacer(1));
+    
+    // Show command if available
+    if (command && command.trim()) {
+      const maxCommandLength = 60; // Prevent command from taking too much space
+      const displayCommand =
+        command.length > maxCommandLength
+          ? command.slice(0, maxCommandLength) + "..."
+          : command;
+      container.addChild(
+        new Text(theme.fg("dim", `  Command: ${displayCommand}`), 1, 0),
+      );
+      container.addChild(new Spacer(1));
+    }
+    
     container.addChild(
       new Text(theme.fg("dim", `  Cwd:  ${cwdDisplay}`), 1, 0),
     );


### PR DESCRIPTION
On smaller screens the prompt takes up all the window space and the command is not visible anymore.
So the command is included again for bash calls. 
Read, Write and List are currently not including the command. Maybe they should too?