### PR TITLE
fix(path-access): show bash command and compact prompt actions

### DIFF
--- a/.changeset/fuzzy-command-prompts.md
+++ b/.changeset/fuzzy-command-prompts.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Show bash commands inside path-access prompts, with a toggle for truncated commands.

--- a/.changeset/neat-path-access-options.md
+++ b/.changeset/neat-path-access-options.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Reduce path-access prompt height by grouping approval actions when space allows.

--- a/extensions/path-access/index.test.ts
+++ b/extensions/path-access/index.test.ts
@@ -1,4 +1,5 @@
 import type {
+  BashToolCallEvent,
   ExtensionAPI,
   ExtensionContext,
   ReadToolCallEvent,
@@ -11,6 +12,7 @@ import {
   type GuardrailsPromptOpenedPayload,
 } from "../../src/shared/events";
 import pathAccess from "./index";
+import type { createPathAccessPromptComponent } from "./prompt";
 
 vi.mock("../../src/shared/config", () => ({
   configLoader: {
@@ -37,6 +39,34 @@ const toolCall = {
   toolName: "read",
   input: { path: "/outside/secret.txt" },
 } satisfies ReadToolCallEvent;
+
+const bashToolCall = {
+  type: "tool_call",
+  toolCallId: "test-call",
+  toolName: "bash",
+  input: { command: "cat /outside/secret.txt" },
+} satisfies BashToolCallEvent;
+
+type PathAccessPromptComponent = ReturnType<
+  typeof createPathAccessPromptComponent
+>;
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+function renderPromptComponent(component: PathAccessPromptComponent): string {
+  return component(
+    { terminal: { columns: 100 }, requestRender: vi.fn() },
+    theme,
+    undefined,
+    vi.fn(),
+  )
+    .render(100)
+    .join("\n");
+}
 
 function emittedPromptOpened(pi: DeepMocked<ExtensionAPI>) {
   return pi.events.emit.mock.calls.find(
@@ -100,6 +130,32 @@ describe("pathAccess extension hook", () => {
     expect(pi).toHaveEmitted(
       GUARDRAILS_PROMPT_CLOSED_EVENT,
       expect.objectContaining({ prompt: { id: opened.prompt.id } }),
+    );
+  });
+
+  it("shows the bash command in the outside-path prompt", async () => {
+    const pi = createMock<ExtensionAPI>();
+    const ctx = createMock<ExtensionContext>({
+      cwd: "/workspace",
+      hasUI: true,
+      mode: "tui",
+    });
+    ctx.ui.custom.mockResolvedValue("allow-file-once");
+    await pathAccess(pi);
+
+    const toolCallHandler = registeredExtensionHandler(pi, "tool_call");
+    assert(
+      typeof toolCallHandler === "function",
+      "tool_call handler should be registered",
+    );
+    await toolCallHandler(bashToolCall, ctx);
+
+    const promptComponent = ctx.ui.custom.mock.calls[0]?.[0] as
+      | PathAccessPromptComponent
+      | undefined;
+    assert(promptComponent, "path access prompt should be shown");
+    expect(renderPromptComponent(promptComponent)).toContain(
+      "Command: cat /outside/secret.txt",
     );
   });
 });

--- a/extensions/path-access/index.ts
+++ b/extensions/path-access/index.ts
@@ -70,6 +70,8 @@ export default async function pathAccess(pi: ExtensionAPI) {
     }
 
     const input = event.input as Record<string, unknown>;
+    const bashCommand =
+      event.toolName === "bash" ? String(input.command ?? "") : undefined;
     const targets = [
       ...new Set(await targetsForTool(event.toolName, input, ctx.cwd)),
     ];
@@ -133,6 +135,7 @@ export default async function pathAccess(pi: ExtensionAPI) {
             normalizeForDisplay(parentDir, ctx.cwd),
             ctx.cwd,
             showFileOptions,
+            bashCommand,
           ),
         );
       } finally {

--- a/extensions/path-access/prompt.test.ts
+++ b/extensions/path-access/prompt.test.ts
@@ -111,4 +111,71 @@ describe("createPathAccessPromptComponent", () => {
     expect(commandLine).not.toContain("\u001B");
     expect(commandLine).not.toContain("\u0007");
   });
+
+  it("renders related options side by side when wide enough", () => {
+    const lines = renderPrompt("cat /outside/secret.txt", 100);
+    const fileRow = lines.find((line) =>
+      line.includes("Allow file this session"),
+    );
+    const dirRow = lines.find((line) =>
+      line.includes("Allow directory this session"),
+    );
+
+    expect(fileRow).toContain("Allow file always");
+    expect(dirRow).toContain("Allow directory always");
+  });
+
+  it("renders one option per row when narrow", () => {
+    const lines = renderPrompt("cat /outside/secret.txt", 48);
+    const fileRow = lines.find((line) =>
+      line.includes("Allow file this session"),
+    );
+
+    expect(fileRow).not.toContain("Allow file always");
+  });
+
+  it("keeps tab navigation linear in the compact layout", () => {
+    const { done, prompt } = createPrompt();
+
+    prompt.handleInput?.("\t");
+    prompt.handleInput?.("\r");
+
+    expect(done).toHaveBeenCalledWith("allow-file-session");
+  });
+
+  it("moves right to the next option", () => {
+    const { done, prompt } = createPrompt();
+
+    prompt.handleInput?.("\x1b[C");
+    prompt.handleInput?.("\r");
+
+    expect(done).toHaveBeenCalledWith("allow-file-session");
+  });
+
+  it("moves left to the previous option", () => {
+    const { done, prompt } = createPrompt();
+
+    prompt.handleInput?.("\x1b[D");
+    prompt.handleInput?.("\r");
+
+    expect(done).toHaveBeenCalledWith("deny");
+  });
+
+  it("moves down to the next option", () => {
+    const { done, prompt } = createPrompt();
+
+    prompt.handleInput?.("\x1b[B");
+    prompt.handleInput?.("\r");
+
+    expect(done).toHaveBeenCalledWith("allow-file-session");
+  });
+
+  it("moves up to the previous option", () => {
+    const { done, prompt } = createPrompt();
+
+    prompt.handleInput?.("\x1b[A");
+    prompt.handleInput?.("\r");
+
+    expect(done).toHaveBeenCalledWith("deny");
+  });
 });

--- a/extensions/path-access/prompt.test.ts
+++ b/extensions/path-access/prompt.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPathAccessPromptComponent } from "./prompt";
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+function renderPrompt(command?: string, width = 100): string[] {
+  const component = createPathAccessPromptComponent(
+    "bash",
+    "/outside/secret.txt",
+    "/outside",
+    "/workspace",
+    true,
+    command,
+  );
+
+  return component(
+    { terminal: { columns: width }, requestRender: vi.fn() },
+    theme,
+    undefined,
+    vi.fn(),
+  ).render(width);
+}
+
+function createPrompt(width = 100, command = "cat /outside/secret.txt") {
+  const done = vi.fn();
+  const requestRender = vi.fn();
+  const component = createPathAccessPromptComponent(
+    "bash",
+    "/outside/secret.txt",
+    "/outside",
+    "/workspace",
+    true,
+    command,
+  );
+  const prompt = component(
+    { terminal: { columns: width }, requestRender },
+    theme,
+    undefined,
+    done,
+  );
+
+  prompt.render(width);
+  return { done, prompt, requestRender };
+}
+
+describe("createPathAccessPromptComponent", () => {
+  it("shows the command when provided", () => {
+    expect(renderPrompt("cat /outside/secret.txt").join("\n")).toContain(
+      "Command: cat /outside/secret.txt",
+    );
+  });
+
+  it("omits the command row when not provided", () => {
+    expect(renderPrompt().join("\n")).not.toContain("Command:");
+  });
+
+  it("truncates long commands to fit the prompt width", () => {
+    const lines = renderPrompt(
+      "cat /outside/very/long/path/that/keeps/going/target.txt",
+      48,
+    );
+    const commandLine = lines.find((line) => line.includes("Command:"));
+
+    expect(commandLine).toContain("…");
+    expect(commandLine).not.toContain("target.txt");
+  });
+
+  it("shows the command expand shortcut only when truncated", () => {
+    expect(
+      renderPrompt("cat /outside/secret.txt", 100).join("\n"),
+    ).not.toContain("expand command");
+
+    expect(
+      renderPrompt(
+        "cat /outside/very/long/path/that/keeps/going/target.txt",
+        48,
+      ).join("\n"),
+    ).toContain("x expand command");
+  });
+
+  it("expands truncated commands into wrapped full text", () => {
+    const command =
+      "python -c 'print(1)' && cat /outside/very/long/path/that/keeps/going/target.txt";
+    const { prompt } = createPrompt(88, command);
+
+    expect(prompt.render(88).join("\n")).not.toContain("target.txt");
+    prompt.handleInput?.("x");
+
+    const expanded = prompt.render(88).join("\n");
+    expect(expanded).toContain("target.txt");
+    expect(expanded).toContain("x collapse command");
+  });
+
+  it("collapses multi-line commands to a single row", () => {
+    const lines = renderPrompt("printf 'a'\ncat\t/outside/secret.txt");
+    const commandLines = lines.filter((line) => line.includes("Command:"));
+
+    expect(commandLines).toHaveLength(1);
+    expect(commandLines[0]).toContain("printf 'a' ⏎ cat /outside/secret.txt");
+  });
+
+  it("escapes terminal control characters in commands", () => {
+    const lines = renderPrompt("printf '\u001B]52;c;bad\u0007'");
+    const commandLine = lines.find((line) => line.includes("Command:"));
+
+    expect(commandLine).toContain("␛]52;c;bad�");
+    expect(commandLine).not.toContain("\u001B");
+    expect(commandLine).not.toContain("\u0007");
+  });
+});

--- a/extensions/path-access/prompt.ts
+++ b/extensions/path-access/prompt.ts
@@ -30,6 +30,76 @@ function displayCwd(cwd: string): string {
   return cwd;
 }
 
+const MAX_COMMAND_DISPLAY_WIDTH = 500;
+const ELLIPSIS = "…";
+
+function truncateVisibleEnd(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (visibleWidth(text) <= maxWidth) return text;
+  if (maxWidth <= visibleWidth(ELLIPSIS)) return ELLIPSIS;
+
+  let result = "";
+  for (const char of Array.from(text)) {
+    if (visibleWidth(`${result}${char}${ELLIPSIS}`) > maxWidth) break;
+    result += char;
+  }
+
+  return `${result}${ELLIPSIS}`;
+}
+
+function normalizeCommand(command: string): string {
+  const collapsed = command
+    .replace(/\r\n/g, "\n")
+    .replace(/[\r\n]+/g, " ⏎ ")
+    .replace(/\t+/g, " ")
+    .replace(/ {2,}/g, " ")
+    .trim();
+
+  let safe = "";
+  for (const char of collapsed) {
+    const code = char.charCodeAt(0);
+    if (code === 0x1b) {
+      safe += "␛";
+    } else if (code <= 0x1f || code === 0x7f) {
+      safe += "�";
+    } else {
+      safe += char;
+    }
+  }
+
+  return safe;
+}
+
+interface CommandRow {
+  text: string;
+  truncated: boolean;
+}
+
+function collapsedCommandRow(
+  command: string,
+  contentWidth: number,
+): CommandRow {
+  const prefix = "  Command: ";
+  if (visibleWidth(prefix) >= contentWidth) {
+    return { text: truncateVisibleEnd(prefix, contentWidth), truncated: true };
+  }
+
+  const capped = truncateVisibleEnd(command, MAX_COMMAND_DISPLAY_WIDTH);
+  const commandWidth = Math.max(0, contentWidth - visibleWidth(prefix));
+  const text = `${prefix}${truncateVisibleEnd(capped, commandWidth)}`;
+
+  return {
+    text,
+    truncated:
+      visibleWidth(command) > MAX_COMMAND_DISPLAY_WIDTH ||
+      visibleWidth(command) > commandWidth,
+  };
+}
+
+function expandedCommandRow(command: string): string {
+  return `  Command: ${command}`;
+}
+
 interface PromptOption {
   label: string;
   result: PromptResult;
@@ -64,6 +134,7 @@ export function createPathAccessPromptComponent(
   displayDir: string,
   cwd: string,
   showFileOptions: boolean,
+  command?: string,
 ) {
   return (
     tui: { terminal: { columns: number }; requestRender(): void },
@@ -77,10 +148,13 @@ export function createPathAccessPromptComponent(
   ) => {
     const options = showFileOptions ? FILE_OPTIONS : DIR_OPTIONS;
     let selectedIndex = 0;
+    let commandExpanded = false;
+    let commandCanExpand = false;
 
     const container = new Container();
     const border = (s: string) => theme.fg("warning", s);
     const cwdDisplay = displayCwd(cwd);
+    const normalizedCommand = command ? normalizeCommand(command) : "";
 
     container.addChild(
       new Text(
@@ -100,6 +174,12 @@ export function createPathAccessPromptComponent(
         0,
       ),
     );
+    const commandLine = normalizedCommand
+      ? new Text(theme.fg("dim", ""), 1, 0)
+      : undefined;
+    if (commandLine) {
+      container.addChild(commandLine);
+    }
     container.addChild(new Spacer(1));
     container.addChild(
       new Text(theme.fg("dim", `  Cwd:  ${cwdDisplay}`), 1, 0),
@@ -119,13 +199,8 @@ export function createPathAccessPromptComponent(
     }
 
     container.addChild(new Spacer(1));
-    container.addChild(
-      new Text(
-        theme.fg("dim", "↑/↓/Tab select · Enter select · Esc deny"),
-        1,
-        0,
-      ),
-    );
+    const footerLine = new Text("", 1, 0);
+    container.addChild(footerLine);
 
     const renderOptions = () => {
       for (let i = 0; i < options.length; i++) {
@@ -149,10 +224,41 @@ export function createPathAccessPromptComponent(
       tui.requestRender();
     };
 
+    const requestRender = () => {
+      tui.requestRender();
+    };
+
     return {
       render: (width: number) => {
         const innerWidth = Math.max(1, width - 2);
         const contentWidth = Math.max(1, width - 4);
+        const textContentWidth = Math.max(1, contentWidth - 2);
+        if (commandLine) {
+          const collapsed = collapsedCommandRow(
+            normalizedCommand,
+            textContentWidth,
+          );
+          commandCanExpand = collapsed.truncated;
+          commandLine.setText(
+            theme.fg(
+              "dim",
+              commandExpanded
+                ? expandedCommandRow(normalizedCommand)
+                : collapsed.text,
+            ),
+          );
+        }
+        const commandToggleHint = commandCanExpand
+          ? commandExpanded
+            ? " · x collapse command"
+            : " · x expand command"
+          : "";
+        footerLine.setText(
+          theme.fg(
+            "dim",
+            `↑/↓/Tab select · Enter select · Esc deny${commandToggleHint}`,
+          ),
+        );
         const raw = container.render(contentWidth);
         const top = border(`╭${"─".repeat(innerWidth)}╮`);
         const bottom = border(`╰${"─".repeat(innerWidth)}╯`);
@@ -181,6 +287,11 @@ export function createPathAccessPromptComponent(
           matchesKey(data, Key.tab)
         ) {
           moveSelection(1);
+          return;
+        }
+        if ((data === "x" || data === "X") && commandCanExpand) {
+          commandExpanded = !commandExpanded;
+          requestRender();
           return;
         }
         if (matchesKey(data, Key.enter)) {

--- a/extensions/path-access/prompt.ts
+++ b/extensions/path-access/prompt.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import {
+  type Component,
   Container,
   Key,
   matchesKey,
@@ -121,12 +122,90 @@ const DIR_OPTIONS: PromptOption[] = [
   { label: "Deny", result: "deny" },
 ];
 
+const OPTION_INDENT = " ";
+const OPTION_COLUMN_GAP = 4;
+
+interface OptionLayout {
+  rows: number[][];
+  columnWidths: number[];
+}
+
+function naturalOptionWidth(option: PromptOption): number {
+  return visibleWidth(option.label) + 2;
+}
+
+function oneColumnRows(options: PromptOption[]): number[][] {
+  return options.map((_, index) => [index]);
+}
+
+function compactRows(options: PromptOption[]): number[][] {
+  if (options.length === FILE_OPTIONS.length) return [[0], [1, 2], [3, 4], [5]];
+  if (options.length === DIR_OPTIONS.length) return [[0], [1, 2], [3]];
+  return oneColumnRows(options);
+}
+
+function optionColumnWidths(
+  options: PromptOption[],
+  rows: number[][],
+): number[] {
+  const widths: number[] = [];
+  for (const row of rows) {
+    for (let column = 0; column < row.length; column++) {
+      const option = options[row[column]];
+      if (!option) continue;
+      widths[column] = Math.max(
+        widths[column] ?? 0,
+        naturalOptionWidth(option),
+      );
+    }
+  }
+  return widths;
+}
+
+function layoutWidth(layout: OptionLayout): number {
+  const columnsWidth = layout.columnWidths.reduce(
+    (sum, width) => sum + width,
+    0,
+  );
+  const gapsWidth =
+    Math.max(0, layout.columnWidths.length - 1) * OPTION_COLUMN_GAP;
+  return visibleWidth(OPTION_INDENT) + columnsWidth + gapsWidth;
+}
+
+function createOptionLayout(
+  options: PromptOption[],
+  width: number,
+): OptionLayout {
+  const availableWidth = Math.max(1, width - visibleWidth(OPTION_INDENT));
+  const compact = {
+    rows: compactRows(options),
+    columnWidths: optionColumnWidths(options, compactRows(options)),
+  };
+
+  if (
+    compact.rows.some((row) => row.length > 1) &&
+    layoutWidth(compact) <= width
+  ) {
+    return compact;
+  }
+
+  return {
+    rows: oneColumnRows(options),
+    columnWidths: [
+      Math.min(
+        availableWidth,
+        Math.max(...options.map((option) => naturalOptionWidth(option))),
+      ),
+    ],
+  };
+}
+
 /**
  * Build the confirmation UI component.
  * For directory-oriented tools (ls, find): only directory grant options.
  * For file tools and bash: both file and directory options.
  * Options rendered as highlighted tabs (selected = accent bg, unselected = dim),
- * navigable with ←/→/Tab/Shift+Tab.
+ * navigable linearly with arrows/Tab/Shift+Tab.
  */
 export function createPathAccessPromptComponent(
   toolName: string,
@@ -148,6 +227,7 @@ export function createPathAccessPromptComponent(
   ) => {
     const options = showFileOptions ? FILE_OPTIONS : DIR_OPTIONS;
     let selectedIndex = 0;
+    let optionLayout = createOptionLayout(options, tui.terminal.columns);
     let commandExpanded = false;
     let commandCanExpand = false;
 
@@ -192,40 +272,44 @@ export function createPathAccessPromptComponent(
     );
     container.addChild(new Spacer(1));
 
-    // Dynamically rendered option lines
-    const optionLines: Text[] = options.map(() => new Text("", 1, 0));
-    for (const line of optionLines) {
-      container.addChild(line);
-    }
+    const optionGrid: Component = {
+      render: (width: number) => {
+        optionLayout = createOptionLayout(options, width);
+        return optionLayout.rows.map((row) => {
+          const cells = row.map((optionIndex, column) => {
+            const option = options[optionIndex];
+            const cellWidth = optionLayout.columnWidths[column] ?? 1;
+            const labelWidth = Math.max(1, cellWidth - 2);
+            const label = truncateVisibleEnd(option.label, labelWidth);
+            const raw = ` ${label} `;
+            const pad = Math.max(0, cellWidth - visibleWidth(raw));
+            const styled =
+              optionIndex === selectedIndex
+                ? theme.bg("selectedBg", theme.fg("accent", raw))
+                : theme.fg("dim", raw);
+
+            return `${styled}${" ".repeat(pad)}`;
+          });
+
+          return `${OPTION_INDENT}${cells.join(" ".repeat(OPTION_COLUMN_GAP))}`;
+        });
+      },
+      invalidate: () => {},
+    };
+    container.addChild(optionGrid);
 
     container.addChild(new Spacer(1));
     const footerLine = new Text("", 1, 0);
     container.addChild(footerLine);
 
-    const renderOptions = () => {
-      for (let i = 0; i < options.length; i++) {
-        const label = options[i].label;
-        if (i === selectedIndex) {
-          optionLines[i].setText(
-            theme.bg("selectedBg", theme.fg("accent", ` ${label} `)),
-          );
-        } else {
-          optionLines[i].setText(theme.fg("dim", ` ${label} `));
-        }
-      }
-    };
-
-    renderOptions();
-
-    const moveSelection = (direction: number) => {
-      selectedIndex =
-        (selectedIndex + direction + options.length) % options.length;
-      renderOptions();
-      tui.requestRender();
-    };
-
     const requestRender = () => {
       tui.requestRender();
+    };
+
+    const moveLinear = (direction: number) => {
+      selectedIndex =
+        (selectedIndex + direction + options.length) % options.length;
+      requestRender();
     };
 
     return {
@@ -256,7 +340,7 @@ export function createPathAccessPromptComponent(
         footerLine.setText(
           theme.fg(
             "dim",
-            `↑/↓/Tab select · Enter select · Esc deny${commandToggleHint}`,
+            `←/→/↑/↓/Tab select · Enter select · Esc deny${commandToggleHint}`,
           ),
         );
         const raw = container.render(contentWidth);
@@ -275,18 +359,28 @@ export function createPathAccessPromptComponent(
       handleInput: (data: string) => {
         if (
           matchesKey(data, Key.up) ||
+          matchesKey(data, Key.left) ||
           data === "k" ||
-          matchesKey(data, Key.shift("tab"))
+          data === "h"
         ) {
-          moveSelection(-1);
+          moveLinear(-1);
           return;
         }
         if (
           matchesKey(data, Key.down) ||
+          matchesKey(data, Key.right) ||
           data === "j" ||
-          matchesKey(data, Key.tab)
+          data === "l"
         ) {
-          moveSelection(1);
+          moveLinear(1);
+          return;
+        }
+        if (matchesKey(data, Key.shift("tab"))) {
+          moveLinear(-1);
+          return;
+        }
+        if (matchesKey(data, Key.tab)) {
+          moveLinear(1);
           return;
         }
         if ((data === "x" || data === "X") && commandCanExpand) {


### PR DESCRIPTION
Supersedes PR #78.

## Summary
- Show bash commands inside outside-workspace path-access prompts.
- Add `x` toggle to expand/collapse truncated commands.
- Compact approval actions into grouped rows when width allows, with narrow fallback.
- Keep option navigation linear with arrows and Tab.

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:schema`