### PR TITLE
fix(path-access): handle find expressions and xargs patterns in path extraction

### DIFF
--- a/.changeset/fix-windows-find-xargs-paths.md
+++ b/.changeset/fix-windows-find-xargs-paths.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Fix bogus "Outside Workspace Access" prompts on Windows for `find <dir> \( ... \) | xargs grep ...` commands (#79). Escaped parens in find expressions produced a lone `\` token that resolved to the drive root (`D:\`) on Windows, and grep patterns passed through `xargs` were treated as paths. Requires @aliou/sh ^0.2.2, which fixes backslash escape tokenization.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@aliou/pi-utils-settings": "^0.17.0",
-    "@aliou/sh": "^0.1.0"
+    "@aliou/sh": "^0.2.2"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.17.0
         version: 0.17.0(@earendil-works/pi-coding-agent@0.79.6(ws@8.19.0)(zod@3.25.76))(@earendil-works/pi-tui@0.79.6)
       '@aliou/sh':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.2.2
+        version: 0.2.2
     devDependencies:
       '@aliou/biome-plugins':
         specifier: ^0.8.1
@@ -81,12 +81,9 @@ packages:
       '@earendil-works/pi-tui':
         optional: true
 
-  '@aliou/sh@0.1.0':
-    resolution: {integrity: sha512-MtVSUqNAHK8a0yQdwv4ADlTIBnEg8bpFXcqp0PaxwqxhSWAxcIrpAIPbsc3CJnUK3R++BcgaxBZ5saicHtU+8Q==}
+  '@aliou/sh@0.2.2':
+    resolution: {integrity: sha512-fHcGEFDzRSv+z2r+ysWw47NlhaYrU2FujwMviWtyaZ71bHDXz8FI9VcP3jEkL5b2Otx2fc/QahyouaY0xV96Mw==}
     engines: {node: '>=22'}
-
-  '@golevelup/ts-vitest@4.0.0':
-    resolution: {integrity: sha512-TNIhtox9zWfxlww0ql91l/k2zDthN4owg5qDieRHtjIwIvuoUlXLiwqAb/ifkRr8K+jZLRIC9QrKN/J7TBghlQ==}
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -340,6 +337,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@golevelup/ts-vitest@4.0.0':
+    resolution: {integrity: sha512-TNIhtox9zWfxlww0ql91l/k2zDthN4owg5qDieRHtjIwIvuoUlXLiwqAb/ifkRr8K+jZLRIC9QrKN/J7TBghlQ==}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -1786,9 +1786,7 @@ snapshots:
       '@earendil-works/pi-coding-agent': 0.79.6(ws@8.19.0)(zod@3.25.76)
       '@earendil-works/pi-tui': 0.79.6
 
-  '@aliou/sh@0.1.0': {}
-
-  '@golevelup/ts-vitest@4.0.0': {}
+  '@aliou/sh@0.2.2': {}
 
   '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
     dependencies:
@@ -2289,6 +2287,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@golevelup/ts-vitest@4.0.0': {}
 
   '@google/genai@1.52.0':
     dependencies:

--- a/src/core/shell/ast.ts
+++ b/src/core/shell/ast.ts
@@ -32,16 +32,21 @@ function partToString(part: WordPart): string {
       return part.value;
     case "DblQuoted":
       return part.parts.map(partToString).join("");
-    case "ParamExp":
-      return part.short
-        ? `$${part.param.value}`
-        : `\${${part.param.value}${part.op ?? ""}${part.value ? wordToString(part.value) : ""}}`;
+    case "ParamExp": {
+      if (part.short) return `$${part.param.value}`;
+      const inner = `${part.excl ? "!" : ""}${part.length ? "#" : ""}${part.param.value}${part.exp ? `${part.exp.op}${part.exp.word ? wordToString(part.exp.word) : ""}` : ""}`;
+      return `\${${inner}}`;
+    }
     case "CmdSubst":
       return "$(...)";
     case "ArithExp":
-      return `$((${part.expr}))`;
+      return "$((...))";
     case "ProcSubst":
       return `${part.op}(...)`;
+    case "BraceExp":
+      return part.elems.map(wordToString).join(",");
+    case "ExtGlob":
+      return `${part.op}${part.pattern})`;
   }
 }
 

--- a/src/core/shell/command-args.test.ts
+++ b/src/core/shell/command-args.test.ts
@@ -59,6 +59,57 @@ describe("classifyCommandArgs", () => {
     ]);
   });
 
+  // Regression: github issue #79 — escaped parens from `find ... \( ... \)`
+  // become `\` words, which resolve to the drive root on Windows
+  // (resolve("D:\\Code\\app", "\\") === "D:\\") and trigger a bogus
+  // outside-workspace prompt.
+  it("ignores escaped parens and operators in find expressions", () => {
+    expect(
+      tokens("find", [
+        "D:/Code/wandering-alchemist",
+        "-type",
+        "f",
+        "\\",
+        "-name",
+        "*.cs",
+        "-o",
+        "-name",
+        "*.gd",
+        "\\",
+      ]),
+    ).toEqual(["D:/Code/wandering-alchemist"]);
+  });
+
+  it("keeps multiple find roots before the expression", () => {
+    expect(
+      tokens("find", [
+        "./src",
+        "./tests",
+        "-name",
+        "*.ts",
+        "-o",
+        "-name",
+        "*.tsx",
+      ]),
+    ).toEqual(["./src", "./tests"]);
+  });
+
+  it("ignores grep patterns containing escaped pipes", () => {
+    expect(
+      tokens("grep", ["-l", "Hitbox\\|hitbox\\|IsChisel", "./src"]),
+    ).toEqual(["./src"]);
+  });
+
+  // xargs forwards args to a nested command; classification must apply to
+  // the wrapped command so its patterns are not treated as paths.
+  it("classifies xargs-wrapped commands as their inner command", () => {
+    expect(tokens("xargs", ["grep", "-l", "Hitbox\\|hitbox"])).toEqual([]);
+  });
+
+  it("keeps xargs-wrapped file operands", () => {
+    expect(tokens("xargs", ["grep", "pattern", "./src"])).toEqual(["./src"]);
+  });
+
   it("ignores jq filters and keeps file operands", () => {
     expect(tokens("jq", ['.path | test("^/tmp/")', "./data.json"])).toEqual([
       "./data.json",

--- a/src/core/shell/command-args.ts
+++ b/src/core/shell/command-args.ts
@@ -22,6 +22,12 @@ export function classifyCommandArgs(
 ): ClassifiedArg[] {
   const cmd = normalizeCommandName(command);
 
+  // xargs appends piped args to a nested command. Find the wrapped command
+  // (first non-flag token, skipping option values that are not paths) and
+  // classify the remaining fixed args as that command's arguments so its
+  // patterns (e.g. `xargs grep -l "a\|b"`) are not treated as paths.
+  if (cmd === "xargs") return classifyXargsArgs(args);
+
   if (cmd === "awk" || cmd === "gawk" || cmd === "mawk" || cmd === "nawk") {
     return classifyAwkArgs(args);
   }
@@ -162,7 +168,14 @@ function classifyFindArgs(args: string[]): ClassifiedArg[] {
   ]);
   for (let i = 0; i < args.length; i++) {
     const arg = args[i] as string;
-    if (!inExpression && !arg.startsWith("-") && arg !== "(" && arg !== "!") {
+    // Escaped parens `\(` `\)` arrive as lone `\` words after AST parsing;
+    // treat them as expression operators, never as path roots. On Windows
+    // resolve(cwd, "\\") is the drive root, which breaks boundary checks.
+    if (arg === "\\" || arg === "(" || arg === ")" || arg === "!") {
+      inExpression = true;
+      continue;
+    }
+    if (!inExpression && !arg.startsWith("-")) {
       out.push({ token: arg });
       continue;
     }
@@ -170,6 +183,35 @@ function classifyFindArgs(args: string[]): ClassifiedArg[] {
     if (patternOptions.has(arg)) i++;
   }
   return out;
+}
+
+/**
+ * xargs runs a nested command with piped args appended. Skip leading xargs
+ * options (values of -I/-J/-L/-n/-P/-s/-0 etc. are not paths), then classify
+ * the rest as the wrapped command's arguments. Bare `xargs` defaults to echo;
+ * `xargs -0 rm` style invocations classify as `rm`.
+ */
+function classifyXargsArgs(args: string[]): ClassifiedArg[] {
+  const optionsWithValues = new Set([
+    "-I",
+    "-J",
+    "-L",
+    "-n",
+    "-P",
+    "-s",
+    "-S",
+    "-E",
+  ]);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string;
+    if (optionsWithValues.has(arg)) {
+      i++;
+      continue;
+    }
+    if (isOption(arg)) continue;
+    return classifyCommandArgs(arg, args.slice(i + 1));
+  }
+  return [];
 }
 
 function classifyFilterCommandArgs(args: string[]): ClassifiedArg[] {

--- a/src/shared/paths/bash-paths.test.ts
+++ b/src/shared/paths/bash-paths.test.ts
@@ -114,6 +114,18 @@ describe("extractBashPathCandidates", () => {
     expect(result).toEqual([]);
   });
 
+  // Regression: github issue #79 — `find <dir> \( ... \) | xargs grep -l
+  // "a\|b"` produces `\` words and an escaped-pipe grep pattern that were
+  // treated as paths. On Windows, resolve(cwd, "\\") collapses to the drive
+  // root (D:\), triggering a bogus outside-workspace prompt.
+  it("ignores find expression tokens and xargs grep patterns", async () => {
+    const result = await extractBashPathCandidates(
+      'find ./src -type f \\( -name "*.cs" -o -name "*.gd" \\) | xargs grep -l "Hitbox\\|hitbox" 2>/dev/null',
+      CWD,
+    );
+    expect(result).toEqual(["/work/project/src", "/dev/null"]);
+  });
+
   describe("when command has path arguments", () => {
     it("extracts a single absolute path", async () => {
       expect(await extractBashPathCandidates("cat /etc/hosts", CWD)).toEqual([
@@ -141,10 +153,18 @@ describe("extractBashPathCandidates", () => {
     });
 
     it("detects Windows-style paths", async () => {
-      const result = await extractBashPathCandidates("type C:\\foo\\bar", CWD);
+      // Quoted backslashes survive bash escape processing.
+      const quoted = await extractBashPathCandidates(
+        'type "C:\\foo\\bar"',
+        CWD,
+      );
+      expect(quoted).toHaveLength(1);
+      expect(quoted[0]).toContain("C:\\foo\\bar");
 
-      expect(result).toHaveLength(1);
-      expect(result[0]).toContain("C:\\foo\\bar");
+      // Forward-slash drive paths need no quoting.
+      const fwd = await extractBashPathCandidates("ls D:/Code/app", CWD);
+      expect(fwd).toHaveLength(1);
+      expect(fwd[0]).toContain("D:/Code/app");
     });
   });
 

--- a/src/shared/paths/bash-paths.ts
+++ b/src/shared/paths/bash-paths.ts
@@ -77,6 +77,18 @@ export async function extractBashPathCandidates(
             pending.push(addCandidate(arg.token, arg.forcePath));
           }
         }
+      } else {
+        // Subshell fragments (e.g. the `\( ... \)` group of a find
+        // expression) arrive as commands with no name: the "words" are
+        // flags, patterns, and shell punctuation, not paths. Only keep
+        // tokens that look like real paths; skip lone `\` from escaped
+        // parens, which resolves to the drive root on Windows (issue #79).
+        for (const word of words) {
+          if (word === "\\" || word === "(" || word === ")" || word === "!")
+            continue;
+          if (word.startsWith("-") && word !== "-" && word !== "--") continue;
+          pending.push(addCandidate(word));
+        }
       }
       for (const redir of cmd.redirects ?? []) {
         pending.push(addCandidate(wordToString(redir.target), true));


### PR DESCRIPTION
> [!NOTE]
> Automated PR created by Pi (`synthetic/hf:moonshotai/Kimi-K3`).

## Problem

On Windows, `find D:/Code/app -type f \( -name "*.cs" \) | xargs grep -l "a\|b"` triggered an **Outside Workspace Access** prompt for `D:\` — the drive root — even though the command targets the working directory. Reported in #79.

## Root cause

Two layers:

1. **@aliou/sh tokenizer**: backslash escapes in unquoted words were not handled (only line continuations). `\(` tokenized as word `\` + symbol `(`, which the parser read as a subshell, fragmenting the find command. Fixed upstream in @aliou/sh 0.2.2.
2. **pi-guardrails path extraction**: the stray `\` word passes `maybePathLike`, and on Windows `path.resolve(cwd, "\\")` collapses to the drive root — outside the workspace. Additionally, `xargs` was an unknown command, so `xargs grep -l "Hitbox\|hitbox"` treated the grep pattern as a path candidate.

## Changes

- `classifyFindArgs`: skip shell punctuation tokens (`\`, `(`, `)`, `!`) — defense for older @aliou/sh AST shapes
- `classifyCommandArgs`: new `xargs` handling that classifies the wrapped command (`xargs grep -l <pattern>` classifies as grep, skipping the pattern)
- `extractBashPathCandidates`: nameless AST fragments (subshell groups) filter out punctuation and flags
- `wordToString`: updated for @aliou/sh 0.2.2 AST types (`ParamExp.exp`, `ArithExp.x`, new `BraceExp`/`ExtGlob` parts)
- Bump `@aliou/sh` to `^0.2.2`

Regression tests cover the exact command from the issue, escaped-paren find expressions, escaped-pipe grep patterns, and xargs wrapping.

Fixes #79