### PR TITLE
fix: avoid path prompts for ctx7 docs

### DIFF
--- a/.changeset/quiet-ctx7-identifiers.md
+++ b/.changeset/quiet-ctx7-identifiers.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-guardrails": patch
+---
+
+Avoid treating ctx7 documentation repository identifiers as filesystem paths.

--- a/src/core/shell/command-args.ts
+++ b/src/core/shell/command-args.ts
@@ -33,11 +33,69 @@ export function classifyCommandArgs(
     return classifyInterpreterArgs(cmd, args);
   }
   if (cmd === "go") return classifyGoArgs(args);
+
+  if (cmd === "ctx7") return classifyCtx7Args(args);
+  if (isNodePackageRunner(cmd)) {
+    return classifyNodePackageRunnerArgs(cmd, args);
+  }
+
   if (cmd === "cut")
     return skipOptionValues(args, new Set(["-d", "--delimiter"]));
   if (cmd === "sort")
     return skipOptionValues(args, new Set(["-t", "--field-separator"]));
   if (cmd === "tr") return [];
+
+  return args.map((token) => ({ token }));
+}
+
+function isNodePackageRunner(command: string): boolean {
+  return ["pnpm", "npx", "bunx"].includes(command);
+}
+
+type NodePackageInvocation = {
+  packageName: string;
+  packageArgs: string[];
+};
+
+function classifyNodePackageRunnerArgs(
+  command: string,
+  args: string[],
+): ClassifiedArg[] {
+  const invocation = getNodePackageInvocation(command, args);
+  if (
+    invocation &&
+    (invocation.packageName === "ctx7" ||
+      invocation.packageName.startsWith("ctx7@"))
+  ) {
+    return classifyCtx7Args(invocation.packageArgs);
+  }
+
+  return args.map((token) => ({ token }));
+}
+
+function getNodePackageInvocation(
+  command: string,
+  args: string[],
+): NodePackageInvocation | undefined {
+  if (command === "pnpm") {
+    const dlxIndex = args.indexOf("dlx");
+    const packageName = args[dlxIndex + 1];
+
+    if (dlxIndex === -1 || packageName === undefined) return;
+
+    return { packageName, packageArgs: args.slice(dlxIndex + 2) };
+  }
+
+  if (["npx", "bunx"].includes(command)) {
+    const [packageName, ...packageArgs] = args;
+    if (packageName === undefined) return;
+
+    return { packageName, packageArgs };
+  }
+}
+
+function classifyCtx7Args(args: string[]): ClassifiedArg[] {
+  if (args[0] === "docs") return [];
 
   return args.map((token) => ({ token }));
 }

--- a/src/shared/paths/bash-paths.test.ts
+++ b/src/shared/paths/bash-paths.test.ts
@@ -27,6 +27,17 @@ describe("extractBashPathCandidates", () => {
     expect(result).toEqual([]);
   });
 
+  it.each([
+    "ctx7 docs /drizzle-team/drizzle-orm-docs 'SQLite inserts'",
+    "pnpm dlx ctx7@latest docs /drizzle-team/drizzle-orm-docs 'SQLite inserts'",
+    "npx ctx7@latest docs /drizzle-team/drizzle-orm-docs 'SQLite inserts'",
+    "bunx ctx7@latest docs /drizzle-team/drizzle-orm-docs 'SQLite inserts'",
+  ])("does not extract ctx7 docs repository identifiers", async (command) => {
+    const result = await extractBashPathCandidates(command, CWD);
+
+    expect(result).toEqual([]);
+  });
+
   describe("when a command has regular expression arguments", () => {
     it("ignores sed expressions and extracts file operands", async () => {
       const result = await extractBashPathCandidates(


### PR DESCRIPTION
## Summary

Avoid outside-workspace path prompts when Context7 documentation lookups use repository identifiers such as `/drizzle-team/drizzle-orm-docs`.

## Details

- Recognize `ctx7 docs` invoked directly or through `pnpm dlx`, `npx`, and `bunx`.
- Treat the repository identifier as a Context7 argument rather than a filesystem path.
- Preserve normal path detection for other package-runner invocations.

## Tests

- Added coverage for direct, pnpm dlx, npx, and bunx Context7 invocations.
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`