### PR TITLE
feat(path-access): filter non-path args by shape and plausibility

### DIFF
--- a/.changeset/shape-based-path-plausibility.md
+++ b/.changeset/shape-based-path-plausibility.md
@@ -1,0 +1,14 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+path-access: filter non-path bash arguments by shape and filesystem
+plausibility instead of per-command allow-lists.
+
+Arguments that look like paths but are not (Context7 library IDs such as
+`/websites/apisix`, Go package patterns like `./...`, URLs, `user@host:` remote
+targets, `docker -v /src:/dst` volume specs) no longer trigger outside-workspace
+prompts, for every CLI rather than an enumerated list.
+
+The `awk`, `sed`, `grep`, `jq`, and `go` classifiers are removed as redundant.
+Interpreter, `find`, and delimiter (`cut`/`sort`/`tr`) handling is unchanged.

--- a/.changeset/shape-based-path-plausibility.md
+++ b/.changeset/shape-based-path-plausibility.md
@@ -10,5 +10,9 @@ Arguments that look like paths but are not (Context7 library IDs such as
 targets, `docker -v /src:/dst` volume specs) no longer trigger outside-workspace
 prompts, for every CLI rather than an enumerated list.
 
+Filtering never applies to redirect targets, interpreter programs, commands
+that create missing parent directories, or tokens holding an unexpanded shell
+reference, so real outside-workspace access is still surfaced.
+
 The `awk`, `sed`, `grep`, `jq`, and `go` classifiers are removed as redundant.
 Interpreter, `find`, and delimiter (`cut`/`sort`/`tr`) handling is unchanged.

--- a/extensions/path-access/targets.test.ts
+++ b/extensions/path-access/targets.test.ts
@@ -21,6 +21,7 @@ describe("targetsForTool", () => {
 
   it("extracts paths from PowerShell command strings", async () => {
     const path = "/home/user/.pi/agent/AGENTS.md";
+    vol.fromJSON({ [path]: "# global" });
 
     await expect(
       targetsForTool(
@@ -35,6 +36,7 @@ describe("targetsForTool", () => {
 
   it("extracts paths from Python command strings", async () => {
     const path = "/home/user/.pi/agent/AGENTS.md";
+    vol.fromJSON({ [path]: "# global" });
 
     await expect(
       targetsForTool(

--- a/src/core/paths/plausibility.test.ts
+++ b/src/core/paths/plausibility.test.ts
@@ -4,6 +4,7 @@ import {
   createsPaths,
   effectiveCommandName,
   hasNonPathShape,
+  hasShellExpansion,
   isImplausibleLocalPath,
 } from "./plausibility";
 
@@ -59,6 +60,32 @@ describe("effectiveCommandName", () => {
 
   it("returns undefined for a missing command", () => {
     expect(effectiveCommandName(undefined)).toBeUndefined();
+  });
+});
+
+describe("hasShellExpansion", () => {
+  it.each([
+    "$SC/.env",
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: shell syntax
+    "${OUTSIDE}/key",
+    "$(pwd)/../../etc/shadow",
+    "$((1+1))/x",
+    "`pwd`/../etc/shadow",
+    "/tmp/$USER/data",
+    // `$b` really is an expansion in bash, even mid-token.
+    "/tmp/a$b",
+  ])("detects %s", (token) => {
+    expect(hasShellExpansion(token)).toBe(true);
+  });
+
+  it.each([
+    "/etc/passwd",
+    "~/.ssh/id_rsa",
+    "./src/index.ts",
+    "/tmp/a-b",
+    "a$",
+  ])("leaves %s alone", (token) => {
+    expect(hasShellExpansion(token)).toBe(false);
   });
 });
 

--- a/src/core/paths/plausibility.test.ts
+++ b/src/core/paths/plausibility.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  commandCreatesPaths,
+  createsPaths,
+  effectiveCommandName,
+  hasNonPathShape,
+  isImplausibleLocalPath,
+} from "./plausibility";
+
+describe("hasNonPathShape", () => {
+  it.each([
+    "https://example.com/a/b",
+    "http://localhost:3000/api",
+    "s3://bucket/key",
+    "file://localhost/etc/passwd",
+    "deploy@host:/etc/passwd",
+    "git@github.com:aliou/pi-guardrails.git",
+    "./...",
+    "./pkg/...",
+    "github.com/user/repo/...",
+  ])("rejects %s", (token) => {
+    expect(hasNonPathShape(token)).toBe(true);
+  });
+
+  it.each([
+    "/etc/passwd",
+    "~/.ssh/id_rsa",
+    "./src/index.ts",
+    "../sibling/file.txt",
+    "/tmp/a:b",
+    "/var/log/app.log",
+    "C:\\Users\\me\\file.txt",
+    "/websites/apisix_apache_apisix",
+  ])("accepts %s as a possible path", (token) => {
+    expect(hasNonPathShape(token)).toBe(false);
+  });
+});
+
+describe("effectiveCommandName", () => {
+  it.each([
+    ["sudo", ["mkdir", "-p", "/x"], "mkdir"],
+    ["env", ["FOO=1", "mkdir", "/x"], "mkdir"],
+    ["xargs", ["mkdir", "-p"], "mkdir"],
+    ["npx", ["mkdir", "-p", "/x"], "mkdir"],
+    ["npx", ["ctx7@latest", "docs", "/websites/apisix"], "ctx7"],
+    ["pnpm", ["dlx", "shx", "mkdir"], "mkdir"],
+    ["yarn", ["dlx", "ctx7", "docs"], "ctx7"],
+    ["sudo", ["npx", "ctx7@latest", "docs"], "ctx7"],
+    ["mkdir", ["-p", "/x"], "mkdir"],
+    ["/usr/bin/mkdir", ["-p", "/x"], "mkdir"],
+    ["cat", ["/etc/passwd"], "cat"],
+  ])("%s %j resolves to %s", (command, args, expected) => {
+    expect(effectiveCommandName(command, args)).toBe(expected);
+  });
+
+  it("returns the wrapper when nothing follows it", () => {
+    expect(effectiveCommandName("sudo", [])).toBe("sudo");
+  });
+
+  it("returns undefined for a missing command", () => {
+    expect(effectiveCommandName(undefined)).toBeUndefined();
+  });
+});
+
+describe("createsPaths", () => {
+  it.each([
+    "mkdir",
+    "install",
+    "rsync",
+    "tar",
+    "git",
+    "/usr/bin/mkdir",
+    "MKDIR",
+  ])("treats %s as path-creating", (command) => {
+    expect(createsPaths(command)).toBe(true);
+  });
+
+  it.each([
+    "cat",
+    "ctx7",
+    "go",
+    "grep",
+    undefined,
+  ])("does not treat %s as path-creating", (command) => {
+    expect(createsPaths(command)).toBe(false);
+  });
+});
+
+describe("commandCreatesPaths", () => {
+  it.each([
+    ["env", ["-C", "/tmp", "mkdir", "-p", "/exfil/data"]],
+    ["xargs", ["-I", "{}", "mkdir", "-p", "/exfil/data"]],
+    ["nice", ["-n", "5", "mkdir", "/exfil/data"]],
+    ["strace", ["mkdir", "-p", "/exfil/data"]],
+    ["pnpm", ["exec", "--filter=foo", "mkdir", "/exfil/data"]],
+    ["sudo", ["/bin/mkdir", "-p", "/exfil/data"]],
+  ])("detects a path-creating command in %s %j", (command, args) => {
+    expect(commandCreatesPaths(command, args)).toBe(true);
+  });
+
+  it.each([
+    ["ctx7", ["docs", "/websites/apisix"]],
+    // A path whose basename matches a command name must not count.
+    ["ctx7", ["docs", "/websites/tar"]],
+    ["gh", ["pr", "view", "12"]],
+    ["cat", ["/etc/passwd"]],
+  ])("does not fire for %s %j", (command, args) => {
+    expect(commandCreatesPaths(command, args)).toBe(false);
+  });
+});
+
+describe("isImplausibleLocalPath", () => {
+  const exists = (set: string[]) => (path: string) => set.includes(path);
+
+  it("accepts a path that exists", () => {
+    expect(isImplausibleLocalPath("/etc/passwd", exists(["/etc/passwd"]))).toBe(
+      false,
+    );
+  });
+
+  it("accepts a missing file whose parent exists", () => {
+    expect(isImplausibleLocalPath("/tmp/new.txt", exists(["/tmp"]))).toBe(
+      false,
+    );
+  });
+
+  it("rejects a missing path whose parent is also missing", () => {
+    expect(isImplausibleLocalPath("/websites/apisix", exists(["/"]))).toBe(
+      true,
+    );
+  });
+
+  it("accepts a missing top-level entry, since the root always exists", () => {
+    // `/exfil` itself is reported; only `/exfil/data` is suppressed. Keeping
+    // top-level targets means `rm -rf /nope` is still surfaced.
+    expect(isImplausibleLocalPath("/exfil", exists([]))).toBe(false);
+  });
+
+  it("never rejects the filesystem root", () => {
+    expect(isImplausibleLocalPath("/", exists([]))).toBe(false);
+  });
+});

--- a/src/core/paths/plausibility.ts
+++ b/src/core/paths/plausibility.ts
@@ -1,0 +1,228 @@
+import { basename, dirname } from "node:path";
+
+/**
+ * Command-agnostic filters that keep non-path argv tokens from being reported
+ * as filesystem access.
+ *
+ * Background: bash path extraction treats any token containing a separator as
+ * a path candidate. Many CLIs use slash-bearing identifiers that are not paths
+ * (`ctx7 docs /websites/apisix`, `go test ./...`, `docker run -v /a:/b`,
+ * `git clone git@host:owner/repo.git`). The previous fix for each of these was
+ * another hardcoded per-command classifier, which does not scale: the set of
+ * CLIs is unbounded.
+ *
+ * These filters key on token shape and filesystem state instead of command
+ * identity, so they cover CLIs nobody has enumerated.
+ *
+ * Safety model:
+ *  - Only outside-workspace candidates are filtered. In-workspace candidates
+ *    are always allowed by `checkPathAccess`, so noise there is harmless.
+ *  - Never applied to `forcePath` tokens (redirect targets, `-o`/`-f` values).
+ *  - Never applied to commands that create missing parent directories.
+ */
+
+/** `https://…`, `file://…`, `s3://…`. */
+const URL_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/** `user@host:/etc/passwd`, `git@github.com:owner/repo.git` — remote, not local. */
+const REMOTE_TARGET = /^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:/;
+
+/** Go package wildcard: `./...`, `./pkg/...`, `github.com/user/repo/...`. */
+const WILDCARD_SEGMENT = /(?:^|\/)\.\.\.(?:\/|$)/;
+
+/**
+ * True when the token's shape rules it out as a local filesystem path,
+ * regardless of which command it was passed to.
+ *
+ * Every pattern here must be one that cannot occur in a legal path, because
+ * rejection happens before any filesystem check. Shapes that merely *usually*
+ * mean "not a path" — such as a `docker run -v /src:/dst` volume spec — are
+ * deliberately absent: `isImplausibleLocalPath` already drops them (the parent
+ * `/src:` does not exist) without risking a real file that contains a colon.
+ */
+export function hasNonPathShape(token: string): boolean {
+  return (
+    URL_SCHEME.test(token) ||
+    REMOTE_TARGET.test(token) ||
+    WILDCARD_SEGMENT.test(token)
+  );
+}
+
+/**
+ * Commands that create missing parent directories, so a not-yet-existing
+ * destination is a real access rather than a misparsed identifier.
+ *
+ * Defined by capability, not by convenience. Adding an entry weakens
+ * `isImplausibleLocalPath` for that command only; omitting one that should be
+ * here means a write to a brand-new outside-workspace root is not surfaced.
+ */
+const PATH_CREATING_COMMANDS = new Set([
+  "7z",
+  "cp",
+  "curl", // --create-dirs
+  "dd",
+  "git",
+  "install",
+  "ln",
+  "mkdir",
+  "mktemp",
+  "mv",
+  "rsync",
+  "tar",
+  "tee",
+  "touch",
+  "unzip",
+  "wget",
+  "zip",
+]);
+
+/**
+ * Prefixes that run another command. Only used to find the effective command
+ * name for `createsPaths`, never to classify arguments, so an unlisted wrapper
+ * cannot re-introduce the identifier false positives this module exists to
+ * remove. It can only cause a missed candidate behind that wrapper.
+ */
+const TRANSPARENT_PREFIXES = new Set([
+  "command",
+  "doas",
+  "env",
+  "nice",
+  "nohup",
+  "shx",
+  "sudo",
+  "time",
+  "xargs",
+]);
+
+/** Package runners: the next token is a package, optionally version-pinned. */
+const PACKAGE_RUNNERS = new Set(["bunx", "npx", "pipx", "uvx"]);
+const SUBCOMMAND_RUNNERS: Record<string, string[]> = {
+  pnpm: ["dlx", "exec"],
+  yarn: ["dlx", "exec"],
+  npm: ["exec"],
+};
+
+function normalize(command: string): string {
+  return basename(command).toLowerCase();
+}
+
+/**
+ * Resolve the command that actually runs, looking through wrappers.
+ *
+ * `sudo mkdir -p /exfil/data` and `npx mkdir -p /exfil/data` must be seen as
+ * `mkdir`, or existence suppression would hide a directory the command itself
+ * creates.
+ */
+export function effectiveCommandName(
+  commandName: string | undefined,
+  args: string[] = [],
+): string | undefined {
+  if (!commandName) return undefined;
+  let cmd = normalize(commandName);
+  let rest = args;
+
+  for (let hops = 0; hops < 3; hops++) {
+    let next: string | undefined;
+
+    if (TRANSPARENT_PREFIXES.has(cmd)) {
+      // Skip flags and `NAME=value` assignments (`env FOO=1 mkdir /x`).
+      const index = rest.findIndex(
+        (arg) => !arg.startsWith("-") && !/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg),
+      );
+      if (index === -1) return cmd;
+      next = rest[index];
+      rest = rest.slice(index + 1);
+    } else if (PACKAGE_RUNNERS.has(cmd)) {
+      const index = rest.findIndex((arg) => !arg.startsWith("-"));
+      if (index === -1) return cmd;
+      next = rest[index];
+      rest = rest.slice(index + 1);
+    } else if (SUBCOMMAND_RUNNERS[cmd]) {
+      const index = rest.findIndex((arg) =>
+        SUBCOMMAND_RUNNERS[cmd]?.includes(arg),
+      );
+      if (index === -1) return cmd;
+      next = rest[index + 1];
+      rest = rest.slice(index + 2);
+    } else {
+      return cmd;
+    }
+
+    if (!next) return cmd;
+    // Strip a version pin: `ctx7@latest`, `cowsay@1.2.3`.
+    cmd = normalize(next.replace(/@[^@/]*$/, "") || next);
+  }
+
+  return cmd;
+}
+
+export function createsPaths(commandName: string | undefined): boolean {
+  if (!commandName) return false;
+  return PATH_CREATING_COMMANDS.has(normalize(commandName));
+}
+
+/**
+ * True when a path-creating command appears anywhere in this command's words.
+ *
+ * `effectiveCommandName` cannot see through wrapper options that take a value
+ * (`env -C /tmp mkdir \u2026`, `xargs -I {} mkdir \u2026`, `nice -n 5 mkdir \u2026`), and
+ * enumerating every wrapper's option grammar is the treadmill this module
+ * exists to avoid. Scanning instead fails in the safe direction: a false hit
+ * only disables suppression for that command, which costs an extra candidate.
+ *
+ * Only separator-free words count, so a path argument whose basename happens
+ * to be a command name (`ctx7 docs /websites/tar`) cannot trigger it.
+ */
+/**
+ * Names too common as subcommands to scan for (`ctx7 skills install \u2026`,
+ * `npm install`, `brew install`). They still count when they are the resolved
+ * command, so `install -D x /exfil/y` and `sudo install \u2026` are unaffected;
+ * only the wrapper-option case (`env -C /tmp install \u2026`) is missed.
+ */
+const NOT_SCANNED = new Set(["install"]);
+
+export function commandCreatesPaths(
+  commandName: string | undefined,
+  args: string[] = [],
+): boolean {
+  if (createsPaths(effectiveCommandName(commandName, args))) return true;
+
+  return args.some(
+    (arg) =>
+      !arg.startsWith("-") &&
+      !arg.includes("/") &&
+      !arg.includes("\\") &&
+      !/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg) &&
+      !NOT_SCANNED.has(arg.toLowerCase()) &&
+      PATH_CREATING_COMMANDS.has(arg.toLowerCase()),
+  );
+}
+
+/**
+ * True when an absolute path is unlikely to be a real filesystem target
+ * because neither it nor its parent directory exists.
+ *
+ * Reads that matter target files that already exist (`/etc/passwd`,
+ * `~/.ssh/id_rsa`), so this never suppresses them. Writes to a missing
+ * directory fail unless the command creates parents — see `createsPaths`.
+ *
+ * It is also evasion-resistant in the obvious direction: creating the root
+ * first (`mkdir -p /exfil`, itself never suppressed) makes the parent exist,
+ * which re-enables reporting for every later access under it.
+ */
+export function isImplausibleLocalPath(
+  absPath: string,
+  pathExists: (path: string) => boolean,
+): boolean {
+  if (pathExists(absPath)) return false;
+
+  const parent = dirname(absPath);
+  if (parent === absPath) return false; // the filesystem root itself
+
+  // A top-level entry (`/exfil`, `C:\exfil`) is always plausible: its parent
+  // is the root, which always exists. This keeps `rm -rf /nope` and
+  // `mkdir /exfil` visible regardless of the create-capable command list.
+  if (dirname(parent) === parent) return false;
+
+  return !pathExists(parent);
+}

--- a/src/core/paths/plausibility.ts
+++ b/src/core/paths/plausibility.ts
@@ -27,6 +27,9 @@ const URL_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
 /** `user@host:/etc/passwd`, `git@github.com:owner/repo.git` — remote, not local. */
 const REMOTE_TARGET = /^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:/;
 
+/** `$VAR`, `${VAR}`, `$(cmd)`, `$((expr))`, `` `cmd` ``. */
+const SHELL_EXPANSION = /\$[A-Za-z_{(]|`/;
+
 /** Go package wildcard: `./...`, `./pkg/...`, `github.com/user/repo/...`. */
 const WILDCARD_SEGMENT = /(?:^|\/)\.\.\.(?:\/|$)/;
 
@@ -154,6 +157,19 @@ export function effectiveCommandName(
   }
 
   return cmd;
+}
+
+/**
+ * True when the token contains an unexpanded shell reference.
+ *
+ * Such a token cannot be resolved to a real path, so the filesystem says
+ * nothing about it: `cat "$(pwd)/../../etc/shadow"` resolves to a directory
+ * that does not exist while the command still reads a real file. Following the
+ * same stance as the `onlyIfExists` fix, an unresolvable reference is treated
+ * as suspicious rather than proven absent.
+ */
+export function hasShellExpansion(token: string): boolean {
+  return SHELL_EXPANSION.test(token);
 }
 
 export function createsPaths(commandName: string | undefined): boolean {

--- a/src/core/shell/command-args.test.ts
+++ b/src/core/shell/command-args.test.ts
@@ -13,48 +13,7 @@ describe("classifyCommandArgs", () => {
   });
 
   it("normalizes command basenames", () => {
-    expect(tokens("/usr/bin/awk", ["/aaa/{print}", "./input"])).toEqual([
-      "./input",
-    ]);
-  });
-
-  it("ignores awk inline program and keeps file operands", () => {
-    expect(tokens("awk", ["/aaa/{print}", "./input"])).toEqual(["./input"]);
-  });
-
-  it.each([
-    ["-f as separate option", ["-f", "./prog.awk", "./input"]],
-    ["-f as joined option", ["-f./prog.awk", "./input"]],
-  ])("keeps awk program files with %s", (_label, args) => {
-    expect(tokens("awk", args)).toEqual(["./prog.awk", "./input"]);
-  });
-
-  it("ignores sed inline scripts and keeps file operands", () => {
-    expect(tokens("sed", ["s#/old#/new#g", "./file"])).toEqual(["./file"]);
-  });
-
-  it.each([
-    ["-f as separate option", ["-f", "./script.sed", "./file"]],
-    ["--file as long option", ["--file", "./script.sed", "./file"]],
-    ["-f as joined option", ["-f./script.sed", "./file"]],
-  ])("keeps sed script files with %s", (_label, args) => {
-    expect(tokens("sed", args)).toEqual(["./script.sed", "./file"]);
-  });
-
-  it("ignores grep patterns and keeps file operands", () => {
-    expect(tokens("grep", ["/api/v1", "./src"])).toEqual(["./src"]);
-  });
-
-  it.each([
-    ["-f as separate option", ["-f", "./patterns", "./src"]],
-    ["--file as long option", ["--file", "./patterns", "./src"]],
-    ["-f as joined option", ["-f./patterns", "./src"]],
-  ])("keeps grep pattern files with %s", (_label, args) => {
-    expect(tokens("grep", args)).toEqual(["./patterns", "./src"]);
-  });
-
-  it("keeps find roots and ignores expression patterns", () => {
-    expect(tokens("find", ["./src", "-regex", ".*/test/.*"])).toEqual([
+    expect(tokens("/usr/bin/find", ["./src", "-name", "*.ts"])).toEqual([
       "./src",
     ]);
   });
@@ -94,125 +53,97 @@ describe("classifyCommandArgs", () => {
     ).toEqual(["./src", "./tests"]);
   });
 
-  it("ignores grep patterns containing escaped pipes", () => {
+  // xargs forwards args to a nested command; classification must apply to
+  // the wrapped command. With per-command pattern classifiers gone, what
+  // this still buys is interpreter handling behind the pipe.
+  it("classifies xargs-wrapped commands as their inner command", () => {
     expect(
-      tokens("grep", ["-l", "Hitbox\\|hitbox\\|IsChisel", "./src"]),
-    ).toEqual(["./src"]);
+      classifyCommandArgs("xargs", ["bash", "-c", "cat /etc/passwd"]),
+    ).toEqual([{ token: "cat /etc/passwd", recurseShell: true }]);
   });
 
-  // xargs forwards args to a nested command; classification must apply to
-  // the wrapped command so its patterns are not treated as paths.
-  it("classifies xargs-wrapped commands as their inner command", () => {
-    expect(tokens("xargs", ["grep", "-l", "Hitbox\\|hitbox"])).toEqual([]);
+  it("skips xargs option values before the wrapped command", () => {
+    expect(
+      classifyCommandArgs("xargs", ["-I", "{}", "sh", "-c", "cat /etc/passwd"]),
+    ).toEqual([{ token: "cat /etc/passwd", recurseShell: true }]);
   });
 
   it("keeps xargs-wrapped file operands", () => {
-    expect(tokens("xargs", ["grep", "pattern", "./src"])).toEqual(["./src"]);
-  });
-
-  it("ignores jq filters and keeps file operands", () => {
-    expect(tokens("jq", ['.path | test("^/tmp/")', "./data.json"])).toEqual([
-      "./data.json",
+    expect(tokens("xargs", ["grep", "pattern", "./src"])).toEqual([
+      "pattern",
+      "./src",
     ]);
   });
 
+  // Pattern-shaped arguments are no longer special-cased per command. They are
+  // returned here and filtered downstream by shape/plausibility checks in
+  // extractBashPathCandidates, which covers every CLI rather than a list.
   it.each([
-    ["-f as separate option", ["-f", "./filter.jq", "./data.json"]],
-    [
-      "--from-file as long option",
-      ["--from-file", "./filter.jq", "./data.json"],
-    ],
-  ])("keeps jq filter files with %s", (_label, args) => {
-    expect(tokens("jq", args)).toEqual(["./filter.jq", "./data.json"]);
+    ["awk", ["/aaa/{print}", "./input"]],
+    ["sed", ["s#/old#/new#g", "./file"]],
+    ["grep", ["/api/v1", "./src"]],
+    ["grep", ["-l", "Hitbox\\|hitbox\\|IsChisel", "./src"]],
+    ["rg", ["/api/v1", "./src"]],
+    ["jq", ['.path | test("^/tmp/")', "./data.json"]],
+    ["go", ["test", "./..."]],
+    ["ctx7", ["docs", "/websites/apisix"]],
+  ])("delegates %s arguments to downstream filtering", (command, args) => {
+    expect(tokens(command, args)).toEqual(args);
   });
 
-  it("extracts paths from interpreter inline code", () => {
-    expect(tokens("python3", ["-c", 'open("/etc/passwd")'])).toEqual([
-      "/etc/passwd",
-    ]);
-  });
-
-  it("marks shell -c code for recursion", () => {
-    expect(classifyCommandArgs("sh", ["-c", "cat /etc/passwd"])).toEqual([
-      { token: "cat /etc/passwd", recurseShell: true },
-    ]);
-  });
-
-  it("handles PowerShell flag casing and aliases", () => {
-    expect(tokens("powershell", ["-c", "Get-Content /etc/passwd"])).toEqual([
-      "/etc/passwd",
-    ]);
-    expect(tokens("pwsh", ["-COMMAND", "Get-Content /etc/passwd"])).toEqual([
-      "/etc/passwd",
-    ]);
-  });
-
-  it("skips PowerShell -EncodedCommand values", () => {
-    expect(tokens("powershell", ["-e", "ZgBvAG8A"])).toEqual([]);
-  });
-
-  it("keeps shell script operands", () => {
-    expect(tokens("bash", ["./setup.sh"])).toEqual(["./setup.sh"]);
-  });
-
-  it("keeps interpreter script operands", () => {
-    expect(tokens("python3", ["./script.py", "./data.json"])).toEqual([
-      "./script.py",
-      "./data.json",
-    ]);
-  });
-
-  it("ignores delimiter args", () => {
-    expect(tokens("cut", ["-d", "/", "./file"])).toEqual(["./file"]);
-    expect(tokens("sort", ["-t", "/", "./file"])).toEqual(["./file"]);
-    expect(tokens("tr", ["/", ":"])).toEqual([]);
-  });
-
-  describe("go subcommand", () => {
-    it("skips Go package wildcard patterns", () => {
-      expect(tokens("go", ["test", "./..."])).toEqual([]);
+  describe("find expressions", () => {
+    it("keeps find roots and ignores expression patterns", () => {
+      expect(tokens("find", ["./src", "-regex", ".*/test/.*"])).toEqual([
+        "./src",
+      ]);
     });
+  });
 
-    it("keeps go run .go file operands", () => {
-      expect(tokens("go", ["run", "main.go"])).toEqual(["main.go"]);
-    });
-
-    it("skips non-.go positionals for go run", () => {
-      expect(tokens("go", ["run", "-exec", "/bin/env", "main.go"])).toEqual([
-        "main.go",
+  describe("interpreters", () => {
+    it("extracts paths from interpreter inline code", () => {
+      expect(tokens("python3", ["-c", 'open("/etc/passwd")'])).toEqual([
+        "/etc/passwd",
       ]);
     });
 
-    it("skips package patterns for build/vet/list", () => {
-      expect(tokens("go", ["build", "./..."])).toEqual([]);
-      expect(tokens("go", ["vet", "./pkg/..."])).toEqual([]);
-      expect(tokens("go", ["list", "./..."])).toEqual([]);
-    });
-
-    it("keeps file-valued flags", () => {
-      expect(tokens("go", ["build", "-modfile", "./go.mod", "./..."])).toEqual([
-        "./go.mod",
+    it("marks shell -c code for recursion", () => {
+      expect(classifyCommandArgs("sh", ["-c", "cat /etc/passwd"])).toEqual([
+        { token: "cat /etc/passwd", recurseShell: true },
       ]);
     });
 
-    it("keeps -o flag value for go build", () => {
-      expect(tokens("go", ["build", "-o", "./bin/app", "./..."])).toEqual([
-        "./bin/app",
+    it("handles PowerShell flag casing and aliases", () => {
+      expect(tokens("powershell", ["-c", "Get-Content /etc/passwd"])).toEqual([
+        "/etc/passwd",
+      ]);
+      expect(tokens("pwsh", ["-COMMAND", "Get-Content /etc/passwd"])).toEqual([
+        "/etc/passwd",
       ]);
     });
 
-    it("handles -C global flag before subcommand", () => {
-      expect(tokens("go", ["-C", "/tmp", "test", "./..."])).toEqual([]);
+    it("skips PowerShell -EncodedCommand values", () => {
+      expect(tokens("powershell", ["-e", "ZgBvAG8A"])).toEqual([]);
     });
 
-    it("handles -C joined form before subcommand", () => {
-      expect(tokens("go", ["-C=/tmp", "test", "./..."])).toEqual([]);
+    it("keeps shell script operands", () => {
+      expect(tokens("bash", ["./setup.sh"])).toEqual(["./setup.sh"]);
     });
 
-    it("keeps go run .go file operands with -C", () => {
-      expect(tokens("go", ["-C", "/tmp", "run", "main.go"])).toEqual([
-        "main.go",
+    it("keeps interpreter script operands", () => {
+      expect(tokens("python3", ["./script.py", "./data.json"])).toEqual([
+        "./script.py",
+        "./data.json",
       ]);
+    });
+  });
+
+  describe("delimiter arguments", () => {
+    // A `/` delimiter exists on every filesystem, so no plausibility check can
+    // reject it. These stay hardcoded.
+    it("ignores delimiter args", () => {
+      expect(tokens("cut", ["-d", "/", "./file"])).toEqual(["./file"]);
+      expect(tokens("sort", ["-t", "/", "./file"])).toEqual(["./file"]);
+      expect(tokens("tr", ["/", ":"])).toEqual([]);
     });
   });
 });

--- a/src/core/shell/command-args.ts
+++ b/src/core/shell/command-args.ts
@@ -16,6 +16,29 @@ function isOption(arg: string): boolean {
   return arg.startsWith("-") && arg !== "-" && arg !== "--";
 }
 
+/**
+ * Classify a command's argv into path candidates.
+ *
+ * Only four categories are special-cased, and each exists for a structural
+ * reason that no shape or filesystem heuristic can recover:
+ *
+ *  0. `xargs` \u2014 it runs a nested command, so its argv has to be re-classified
+ *     as that command's argv.
+ *  1. Interpreters — the program text is an opaque argv token that hides real
+ *     filesystem access (`python3 -c 'open("/etc/passwd")'`). Security
+ *     critical: this is the defense for the wrapper bypass in issue #76.
+ *  2. `find` — its expression grammar mixes roots, patterns, and shell
+ *     punctuation (`\`, `(`, `)`), and a stray `\` resolves to the drive root
+ *     on Windows (issue #79).
+ *  3. Delimiter arguments (`cut -d /`, `sort -t /`, `tr / :`) — the value is
+ *     literally `/`, which exists, so no existence check can reject it.
+ *
+ * Everything else returns every token and is filtered downstream by shape and
+ * plausibility checks in `extractBashPathCandidates`. Commands that merely
+ * take identifier-shaped or pattern-shaped arguments (awk, sed, grep, jq, go,
+ * ctx7, gh, docker, kubectl, …) deliberately have no entry here: enumerating
+ * them does not terminate.
+ */
 export function classifyCommandArgs(
   command: string,
   args: string[],
@@ -24,23 +47,13 @@ export function classifyCommandArgs(
 
   // xargs appends piped args to a nested command. Find the wrapped command
   // (first non-flag token, skipping option values that are not paths) and
-  // classify the remaining fixed args as that command's arguments so its
-  // patterns (e.g. `xargs grep -l "a\|b"`) are not treated as paths.
+  // classify the remaining fixed args as that command's arguments.
   if (cmd === "xargs") return classifyXargsArgs(args);
 
-  if (cmd === "awk" || cmd === "gawk" || cmd === "mawk" || cmd === "nawk") {
-    return classifyAwkArgs(args);
-  }
-  if (cmd === "sed" || cmd === "gsed") return classifySedArgs(args);
-  if (["grep", "egrep", "fgrep", "rg", "ripgrep", "ag", "ack"].includes(cmd)) {
-    return classifyGrepLikeArgs(args);
-  }
   if (cmd === "find" || cmd === "gfind") return classifyFindArgs(args);
-  if (cmd === "jq" || cmd === "yq") return classifyFilterCommandArgs(args);
   if (isInterpreter(cmd)) {
     return classifyInterpreterArgs(cmd, args);
   }
-  if (cmd === "go") return classifyGoArgs(args);
   if (cmd === "cut")
     return skipOptionValues(args, new Set(["-d", "--delimiter"]));
   if (cmd === "sort")
@@ -48,109 +61,6 @@ export function classifyCommandArgs(
   if (cmd === "tr") return [];
 
   return args.map((token) => ({ token }));
-}
-
-function classifyAwkArgs(args: string[]): ClassifiedArg[] {
-  const out: ClassifiedArg[] = [];
-  let sawProgram = false;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string;
-    if (arg === "--") continue;
-    if (arg === "-f") {
-      if (args[i + 1]) out.push({ token: args[++i] as string });
-      sawProgram = true;
-      continue;
-    }
-    if (arg === "-v" || arg === "-F") {
-      i++;
-      continue;
-    }
-    if (arg.startsWith("-f") && arg.length > 2) {
-      out.push({ token: arg.slice(2) });
-      sawProgram = true;
-      continue;
-    }
-    if (isOption(arg)) continue;
-    if (!sawProgram) {
-      sawProgram = true;
-      continue;
-    }
-    out.push({ token: arg });
-  }
-  return out;
-}
-
-function classifySedArgs(args: string[]): ClassifiedArg[] {
-  const out: ClassifiedArg[] = [];
-  let hasExplicitScript = false;
-  let skippedImplicitScript = false;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string;
-    if (arg === "-e" || arg === "--expression") {
-      hasExplicitScript = true;
-      i++;
-      continue;
-    }
-    if (arg === "-f" || arg === "--file") {
-      hasExplicitScript = true;
-      if (args[i + 1]) out.push({ token: args[++i] as string });
-      continue;
-    }
-    if (arg.startsWith("-e") && arg.length > 2) {
-      hasExplicitScript = true;
-      continue;
-    }
-    if (arg.startsWith("-f") && arg.length > 2) {
-      hasExplicitScript = true;
-      out.push({ token: arg.slice(2) });
-      continue;
-    }
-    if (isOption(arg)) continue;
-    if (!hasExplicitScript && !skippedImplicitScript) {
-      skippedImplicitScript = true;
-      continue;
-    }
-    out.push({ token: arg });
-  }
-  return out;
-}
-
-function classifyGrepLikeArgs(args: string[]): ClassifiedArg[] {
-  const out: ClassifiedArg[] = [];
-  let patternProvided = false;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string;
-    if (arg === "-e" || arg === "--regexp") {
-      patternProvided = true;
-      i++;
-      continue;
-    }
-    if (arg === "-f" || arg === "--file") {
-      patternProvided = true;
-      if (args[i + 1]) out.push({ token: args[++i] as string });
-      continue;
-    }
-    if (["-g", "--glob", "-t", "-T", "--type", "--type-not"].includes(arg)) {
-      i++;
-      continue;
-    }
-    if (arg.startsWith("-e") && arg.length > 2) {
-      patternProvided = true;
-      continue;
-    }
-    if (arg.startsWith("-f") && arg.length > 2) {
-      patternProvided = true;
-      out.push({ token: arg.slice(2) });
-      continue;
-    }
-    if (isOption(arg)) continue;
-    if (!patternProvided) {
-      patternProvided = true;
-      continue;
-    }
-    out.push({ token: arg });
-  }
-  return out;
 }
 
 function classifyFindArgs(args: string[]): ClassifiedArg[] {
@@ -214,26 +124,6 @@ function classifyXargsArgs(args: string[]): ClassifiedArg[] {
   return [];
 }
 
-function classifyFilterCommandArgs(args: string[]): ClassifiedArg[] {
-  const out: ClassifiedArg[] = [];
-  let sawFilter = false;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string;
-    if (arg === "-f" || arg === "--from-file") {
-      if (args[i + 1]) out.push({ token: args[++i] as string });
-      sawFilter = true;
-      continue;
-    }
-    if (isOption(arg)) continue;
-    if (!sawFilter) {
-      sawFilter = true;
-      continue;
-    }
-    out.push({ token: arg });
-  }
-  return out;
-}
-
 type InterpreterFlags = {
   /** Flags whose value is an embedded program; paths are extracted from it. */
   codeFlags: Set<string>;
@@ -281,6 +171,15 @@ const CODE_INTERPRETERS = new Set([
 
 function isInterpreter(cmd: string): boolean {
   return SHELL_INTERPRETERS.has(cmd) || CODE_INTERPRETERS.has(cmd);
+}
+
+/**
+ * True when the command runs an arbitrary program supplied on the command
+ * line. Such a program can create directories before writing to them, so its
+ * extracted paths must never be existence-suppressed.
+ */
+export function isInterpreterCommand(command: string): boolean {
+  return isInterpreter(normalizeCommandName(command));
 }
 
 function interpreterFlags(cmd: string): InterpreterFlags {
@@ -384,76 +283,6 @@ function skipOptionValues(
       continue;
     }
     out.push({ token: arg });
-  }
-  return out;
-}
-
-/**
- * Classify `go` subcommand arguments.
- *
- * Go commands take package patterns, not file paths, as positional args
- * for most subcommands. Package patterns like `./...`, `pkg/...`,
- * or `github.com/user/repo/...` use Go's `...` wildcard and are not
- * filesystem paths.
- *
- * `go run` is an exception: it takes .go file operands, emitted with
- * `forcePath` since bare filenames like `main.go` don't pass
- * `maybePathLike`.
- *
- * File-valued flags (e.g. `-o`, `-modfile`, `-overlay`) are kept
- * so that policy checks can still gate them.
- *
- * Global flags like `-C dir` are handled before subcommand detection
- * so their values aren't mistaken for the subcommand.
- */
-function classifyGoArgs(args: string[]): ClassifiedArg[] {
-  const out: ClassifiedArg[] = [];
-  const fileFlags = new Set(["-o", "-modfile", "-overlay"]);
-
-  // Global flags that consume a value and must be skipped before
-  // subcommand detection. E.g. `go -C /tmp test ./...`
-  const globalFlagsWithValues = new Set(["-C"]);
-
-  let subcommand: string | undefined;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string;
-
-    // Handle file-valued flags
-    if (fileFlags.has(arg)) {
-      if (args[i + 1]) out.push({ token: args[++i] as string });
-      continue;
-    }
-
-    // Handle joined file flags like -o=./bin/app
-    if (arg.startsWith("-o=")) {
-      out.push({ token: arg.slice(3) });
-      continue;
-    }
-
-    // Skip global flags with values before subcommand detection
-    if (!subcommand && globalFlagsWithValues.has(arg)) {
-      i++; // skip value
-      continue;
-    }
-    if (!subcommand && arg.startsWith("-C=")) {
-      // joined form -C=/tmp
-      continue;
-    }
-
-    if (isOption(arg)) continue;
-
-    // First non-flag positional is the subcommand
-    if (!subcommand) {
-      subcommand = arg;
-      continue;
-    }
-
-    // `go run` takes .go file operands; emit with forcePath since
-    // bare filenames like main.go don't pass maybePathLike.
-    // All other subcommands take package patterns; skip them.
-    if (subcommand === "run" && arg.endsWith(".go")) {
-      out.push({ token: arg, forcePath: true });
-    }
   }
   return out;
 }

--- a/src/shared/paths/bash-paths.plausibility.test.ts
+++ b/src/shared/paths/bash-paths.plausibility.test.ts
@@ -1,0 +1,248 @@
+import { homedir } from "node:os";
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it } from "vitest";
+import { extractBashPathCandidates } from "./bash-paths";
+
+/**
+ * Shape/plausibility filtering for bash path candidates.
+ *
+ * These cases are all currently reported as outside-workspace paths by the
+ * hardcoded per-command classifier, which only knows about awk/sed/grep/find/
+ * jq/interpreters/go/cut/sort/tr and returns every token for anything else.
+ *
+ * The filter under test is command-agnostic:
+ *  - shape rejection (URL scheme, remote target, volume spec, `...` segment)
+ *  - existence suppression for outside-workspace tokens whose path AND parent
+ *    directory do not exist
+ *
+ * Only outside-workspace candidates are filtered. In-workspace candidates are
+ * always allowed by `checkPathAccess`, so noise there cannot produce a prompt.
+ */
+
+const CWD = "/work/project";
+const HOME = homedir();
+
+/** Nothing outside this tree exists. */
+beforeEach(() => {
+  vol.fromJSON({
+    "/etc/passwd": "",
+    "/tmp/.keep": "",
+    "/var/log/system.log": "",
+    "/work/project/secrets.txt": "",
+    "/work/project/archive.tar": "",
+    "/work/project/archive.zip": "",
+    "/work/project/report.txt": "",
+    [`${HOME}/.ssh/id_rsa`]: "",
+    [`${HOME}/.aws/.keep`]: "",
+  });
+});
+
+const extract = (command: string) => extractBashPathCandidates(command, CWD);
+
+describe("outside-workspace plausibility filter", () => {
+  describe("identifier CLIs (issue #49, PRs #51/#85)", () => {
+    it.each([
+      ['ctx7 docs /drizzle-team/drizzle-orm-docs "how do I query"', "direct"],
+      ['npx ctx7@latest docs /websites/apisix "routes"', "npx"],
+      ['pnpm dlx ctx7 docs /websites/apisix "routes"', "pnpm dlx"],
+      ['bunx ctx7 docs /websites/apisix "routes"', "bunx"],
+      ['pnpm exec ctx7 docs /websites/apisix "routes"', "pnpm exec"],
+      ['yarn dlx ctx7 docs /websites/apisix "routes"', "yarn dlx"],
+      ['uvx ctx7 docs /websites/apisix "routes"', "uvx"],
+      ["ctx7 skills install /aliou/pi-guardrails", "skills install"],
+    ])("ignores the library id in %s (%s)", async (command) => {
+      expect(await extract(command)).toEqual([]);
+    });
+
+    it("ignores library ids inside a nested shell program", async () => {
+      expect(
+        await extract(`bash -c 'npx ctx7 docs /websites/apisix "routes"'`),
+      ).toEqual([]);
+    });
+
+    it("still extracts real paths passed to an unknown runner", async () => {
+      expect(await extract("npx some-cli /etc/passwd")).toEqual([
+        "/etc/passwd",
+      ]);
+    });
+  });
+
+  describe("go package patterns (issue #39) without a go classifier", () => {
+    it.each([
+      "go test ./...",
+      "go build ./...",
+      "go vet ./pkg/...",
+      "go list github.com/user/repo/...",
+    ])("ignores the package pattern in %s", async (command) => {
+      expect(await extract(command)).toEqual([]);
+    });
+
+    it("keeps a real directory passed to go -C", async () => {
+      // `go -C /tmp test ./...` really does chdir to /tmp: that is a genuine
+      // outside-workspace access and should still be surfaced.
+      expect(await extract("go -C /tmp test ./...")).toEqual(["/tmp"]);
+    });
+  });
+
+  describe("other identifier-shaped arguments", () => {
+    it("ignores owner/repo slugs", async () => {
+      expect(
+        await extract("gh pr view 12 --repo /aliou/pi-guardrails"),
+      ).toEqual([]);
+    });
+
+    it("ignores docker volume specs", async () => {
+      // Not a shape rule: `/tmp:` simply does not exist.
+      expect(await extract("docker run -v /tmp:/tmp alpine")).toEqual([]);
+    });
+
+    it("ignores URLs", async () => {
+      expect(await extract("curl https://example.com/a/b")).toEqual([]);
+    });
+
+    it("ignores scp/rsync remote targets", async () => {
+      expect(await extract("scp report.txt deploy@host:/etc/passwd")).toEqual(
+        [],
+      );
+    });
+
+    it("ignores git ssh remotes", async () => {
+      expect(
+        await extract("git clone git@github.com:aliou/pi-guardrails.git"),
+      ).toEqual([]);
+    });
+  });
+
+  describe("in-workspace noise is left alone", () => {
+    // These tokens are not paths either, but they resolve inside the
+    // workspace, where `checkPathAccess` always returns allow. Filtering them
+    // would buy nothing and would cost a stat call per token.
+    it.each([
+      ["kubectl logs pod/api-server-1", ["/work/project/pod/api-server-1"]],
+      [
+        "gh pr view 12 --repo aliou/pi-guardrails",
+        ["/work/project/aliou/pi-guardrails"],
+      ],
+    ])("%s", async (command, expected) => {
+      expect(await extract(command)).toEqual(expected);
+    });
+  });
+
+  describe("real outside-workspace access is still surfaced", () => {
+    it.each([
+      ["cat /etc/passwd", ["/etc/passwd"]],
+      ["cat ~/.ssh/id_rsa", [`${HOME}/.ssh/id_rsa`]],
+      ["cat ~/.aws/credentials", [`${HOME}/.aws/credentials`]],
+      ["tail -f /var/log/system.log", ["/var/log/system.log"]],
+      ["ls /tmp", ["/tmp"]],
+    ])("%s", async (command, expected) => {
+      expect(await extract(command)).toEqual(expected);
+    });
+
+    it("surfaces reads hidden in an interpreter program", async () => {
+      expect(await extract(`python3 -c 'open("/etc/passwd").read()'`)).toEqual([
+        "/etc/passwd",
+      ]);
+    });
+
+    it("surfaces reads hidden in a nested shell program", async () => {
+      expect(await extract(`sh -c 'cat /etc/passwd'`)).toEqual(["/etc/passwd"]);
+    });
+  });
+
+  describe("existence suppression cannot be used to escape", () => {
+    it("never suppresses a redirect target", async () => {
+      // /exfil does not exist, but the redirect creates the file.
+      expect(await extract("cat secrets.txt > /exfil/dump.txt")).toEqual([
+        "/exfil/dump.txt",
+      ]);
+    });
+
+    it.each([
+      "mkdir -p /exfil/data",
+      "rsync -a ./src /exfil/data",
+      "tar -x -C /exfil/data -f archive.tar",
+      "git clone https://example.com/r.git /exfil/data",
+      "unzip archive.zip -d /exfil/data",
+    ])("never suppresses a path-creating command: %s", async (command) => {
+      const result = await extract(command);
+      expect(result).toContain("/exfil/data");
+    });
+
+    it("never suppresses an install -D destination", async () => {
+      expect(
+        await extract("install -D secrets.txt /exfil/data/secrets.txt"),
+      ).toContain("/exfil/data/secrets.txt");
+    });
+
+    it("never suppresses paths from an interpreter program", async () => {
+      // The program can call os.makedirs itself, so a missing parent proves
+      // nothing about whether the write will land.
+      expect(
+        await extract(
+          `python3 -c 'import os; os.makedirs("/exfil/sub"); open("/exfil/sub/data", "w")'`,
+        ),
+      ).toContain("/exfil/sub/data");
+    });
+
+    it("never suppresses curl --create-dirs destinations", async () => {
+      expect(
+        await extract(
+          "curl --create-dirs -o /exfil/sub/f https://example.com/f",
+        ),
+      ).toEqual(["/exfil/sub/f"]);
+    });
+
+    it.each([
+      "sudo mkdir -p /exfil/data",
+      "env mkdir -p /exfil/data",
+      "xargs mkdir -p /exfil/data",
+      "npx mkdir -p /exfil/data",
+      "pnpm dlx shx mkdir -p /exfil/data",
+      "sudo /bin/mkdir -p /exfil/data",
+      // Wrapper options that take a value defeat positional unwrapping, so the
+      // scan has to look at every word.
+      "env -C /tmp mkdir -p /exfil/data",
+      "env -u FOO mkdir -p /exfil/data",
+      "xargs -I {} mkdir -p /exfil/data",
+      "nice -n 5 mkdir -p /exfil/data",
+      "strace mkdir -p /exfil/data",
+      "pnpm exec --filter=foo mkdir -p /exfil/data",
+    ])("looks through wrappers to find the real command: %s", async (cmd) => {
+      expect(await extract(cmd)).toContain("/exfil/data");
+    });
+
+    it("does not treat a path basename as a path-creating command", async () => {
+      // `/websites/tar` must not disable suppression just because its
+      // basename matches an entry in the path-creating list.
+      expect(await extract("ctx7 docs /websites/tar")).toEqual([]);
+    });
+
+    it("still suppresses identifiers behind the same wrappers", async () => {
+      // Wrapper unwrapping only feeds the path-creating lookup; it must not
+      // resurrect the ctx7 false positive.
+      expect(
+        await extract("sudo npx ctx7@latest docs /websites/apisix"),
+      ).toEqual([]);
+    });
+
+    it("surfaces a colon-bearing path that really exists", async () => {
+      vol.fromJSON({ "/tmp/odd:/data": "" });
+      expect(await extract("cat /tmp/odd:/data")).toEqual(["/tmp/odd:/data"]);
+    });
+
+    it("never suppresses a path-creating command nested in a shell", async () => {
+      expect(await extract(`bash -c 'mkdir -p /exfil/data'`)).toContain(
+        "/exfil/data",
+      );
+    });
+
+    it("surfaces a write once the parent exists", async () => {
+      // The two-step evasion (create the root, then write into it) fails:
+      // /tmp exists, so nothing is suppressed.
+      expect(await extract("cp secrets.txt /tmp/exfil.txt")).toEqual([
+        "/tmp/exfil.txt",
+      ]);
+    });
+  });
+});

--- a/src/shared/paths/bash-paths.plausibility.test.ts
+++ b/src/shared/paths/bash-paths.plausibility.test.ts
@@ -113,6 +113,34 @@ describe("outside-workspace plausibility filter", () => {
     });
   });
 
+  describe("unchanged behaviour for known regressions", () => {
+    it("still surfaces the interpreter wrapper bypass (issue #76)", async () => {
+      expect(
+        await extract(
+          `powershell -Command "Get-Content -Path '/etc/passwd' -TotalCount 1"`,
+        ),
+      ).toEqual(["/etc/passwd"]);
+    });
+
+    it("does not add outside-workspace candidates for find/xargs pipelines (issue #79)", async () => {
+      // The lone `\` and the escaped-pipe grep pattern resolve inside the
+      // workspace on POSIX. The Windows drive-root case in #79 is a
+      // tokenizer bug, fixed by the @aliou/sh bump in PR #82, not here.
+      const result = await extract(
+        'find ./src -type f \\( -name "*.cs" \\) | xargs grep -l "a\\|b"',
+      );
+
+      expect(result.filter((path) => !path.startsWith(`${CWD}/`))).toEqual([]);
+      expect(result).toContain(`${CWD}/src`);
+    });
+
+    it("leaves unexpanded policy targets in the workspace alone (PR #84)", async () => {
+      // `$SC/.env` stays a candidate so the policies feature can still judge
+      // it; plausibility filtering never runs on in-workspace tokens.
+      expect(await extract('head "$SC/.env"')).toEqual([`${CWD}/$SC/.env`]);
+    });
+  });
+
   describe("in-workspace noise is left alone", () => {
     // These tokens are not paths either, but they resolve inside the
     // workspace, where `checkPathAccess` always returns allow. Filtering them
@@ -224,6 +252,20 @@ describe("outside-workspace plausibility filter", () => {
       expect(
         await extract("sudo npx ctx7@latest docs /websites/apisix"),
       ).toEqual([]);
+    });
+
+    it.each([
+      // A `$(...)` that expands to a real location resolves, before
+      // expansion, to a directory that does not exist. The filesystem cannot
+      // rule the token out, so it must not be suppressed. Cf. the
+      // `onlyIfExists` bypass in PR #84.
+      'cat "$(pwd)/../../etc/shadow"',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: shell syntax
+      'cat "${OUTSIDE}/../../../etc/shadow"',
+      "cat $SECRETS/../../../etc/shadow",
+      "cat `pwd`/../../etc/shadow",
+    ])("never suppresses an unexpanded shell reference: %s", async (cmd) => {
+      expect(await extract(cmd)).not.toEqual([]);
     });
 
     it("surfaces a colon-bearing path that really exists", async () => {

--- a/src/shared/paths/bash-paths.test.ts
+++ b/src/shared/paths/bash-paths.test.ts
@@ -1,9 +1,25 @@
 import { homedir } from "node:os";
-import { describe, expect, it } from "vitest";
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it } from "vitest";
 import { extractBashPathCandidates } from "./bash-paths";
 
 const CWD = "/work/project";
 const HOME = homedir();
+
+// Outside-workspace candidates are now checked against the filesystem: a
+// token whose path and parent directory are both missing is treated as a
+// misparsed identifier rather than a path. Seed the tree these tests assume.
+beforeEach(() => {
+  vol.fromJSON({
+    "/etc/hosts": "",
+    "/etc/passwd": "",
+    "/tmp/.keep": "",
+    "/a": "",
+    "/b": "",
+    "/work/project/.keep": "",
+    [`${HOME}/.keep`]: "",
+  });
+});
 
 describe("extractBashPathCandidates", () => {
   it("does not extract go package wildcard patterns as paths", async () => {
@@ -12,28 +28,37 @@ describe("extractBashPathCandidates", () => {
     expect(result).toEqual([]);
   });
 
-  it("extracts go run .go file operands", async () => {
+  it("no longer force-extracts bare go run operands", async () => {
+    // `main.go` has no separator, so it is not path-like — the same rule that
+    // already applies to `cat README.md`. It resolves inside the workspace
+    // either way, so path-access allows it.
     const result = await extractBashPathCandidates("go run main.go", CWD);
 
-    expect(result).toEqual(["/work/project/main.go"]);
+    expect(result).toEqual([]);
   });
 
-  it("handles go -C global flag", async () => {
+  it("surfaces the directory go -C changes into", async () => {
+    // `go -C /tmp` really does operate outside the workspace.
     const result = await extractBashPathCandidates(
       "go -C /tmp test ./...",
       CWD,
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(["/tmp"]);
   });
 
   describe("when a command has regular expression arguments", () => {
-    it("ignores sed expressions and extracts file operands", async () => {
+    it("keeps sed expressions in-workspace and extracts file operands", async () => {
+      // The script token is noise, but it resolves inside the workspace where
+      // checkPathAccess always allows, so it cannot produce a prompt.
       const result = await extractBashPathCandidates(
         "sed 's/abc/{2,3}/g' ./file",
         CWD,
       );
-      expect(result).toEqual(["/work/project/file"]);
+      expect(result).toEqual([
+        "/work/project/s/abc/{2,3}/g",
+        "/work/project/file",
+      ]);
     });
 
     it("ignores grep patterns and extracts file operands", async () => {
@@ -49,12 +74,15 @@ describe("extractBashPathCandidates", () => {
       expect(result).toEqual(["/work/project/src"]);
     });
 
-    it("ignores jq filters and extracts file operands", async () => {
+    it("keeps jq filters in-workspace and extracts file operands", async () => {
       const result = await extractBashPathCandidates(
         "jq '.path | test(\"^/tmp/\")' ./data.json",
         CWD,
       );
-      expect(result).toEqual(["/work/project/data.json"]);
+      expect(result).toEqual([
+        '/work/project/.path | test("^/tmp/")',
+        "/work/project/data.json",
+      ]);
     });
 
     it("extracts paths from interpreter inline code", async () => {
@@ -123,7 +151,15 @@ describe("extractBashPathCandidates", () => {
       'find ./src -type f \\( -name "*.cs" -o -name "*.gd" \\) | xargs grep -l "Hitbox\\|hitbox" 2>/dev/null',
       CWD,
     );
-    expect(result).toEqual(["/work/project/src", "/dev/null"]);
+
+    // The `\` words are gone (that was the drive-root bug). The grep pattern
+    // now survives classification as in-workspace noise, which cannot prompt;
+    // what matters is that nothing outside the workspace is invented.
+    expect(result.filter((path) => !path.startsWith(`${CWD}/`))).toEqual([
+      "/dev/null",
+    ]);
+    expect(result).toContain(`${CWD}/src`);
+    expect(result).not.toContain(CWD);
   });
 
   describe("when command has path arguments", () => {

--- a/src/shared/paths/bash-paths.ts
+++ b/src/shared/paths/bash-paths.ts
@@ -1,8 +1,21 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse } from "@aliou/sh";
-import { expandHomePath, maybePathLike } from "../../core/paths/path";
+import {
+  expandHomePath,
+  isWithinBoundary,
+  maybePathLike,
+} from "../../core/paths/path";
+import {
+  commandCreatesPaths,
+  hasNonPathShape,
+  isImplausibleLocalPath,
+} from "../../core/paths/plausibility";
 import { walkCommands, wordToString } from "../../core/shell/ast";
-import { classifyCommandArgs } from "../../core/shell/command-args";
+import {
+  classifyCommandArgs,
+  isInterpreterCommand,
+} from "../../core/shell/command-args";
 import { expandGlob, hasGlobChars } from "../glob";
 
 async function expandCandidate(
@@ -17,10 +30,23 @@ async function expandCandidate(
 /** Maximum nesting depth for recursive shell -c parsing. */
 const MAX_SHELL_DEPTH = 3;
 
+export type ExtractOptions = {
+  /** Nesting level for recursive shell `-c` parsing. Internal. */
+  depth?: number;
+  /** Filesystem existence probe. Injectable for tests. */
+  pathExists?: (path: string) => boolean;
+};
+
 /**
  * Extract path-like candidates from a bash command string.
  * Returns absolute paths. Best-effort: uses AST parsing with regex fallback.
  * Does NOT filter by any policy — returns all path-like arguments.
+ *
+ * Outside-workspace candidates are filtered by shape and filesystem
+ * plausibility (see `core/paths/plausibility`) so that identifier arguments
+ * such as `ctx7 docs /websites/apisix` do not read as filesystem access.
+ * In-workspace candidates are returned unfiltered: `checkPathAccess` allows
+ * them regardless, so noise there is cheaper than another heuristic.
  *
  * `depth` bounds recursion into nested shell `-c` programs to prevent
  * stack exhaustion on deeply nested agent-controlled commands.
@@ -28,21 +54,42 @@ const MAX_SHELL_DEPTH = 3;
 export async function extractBashPathCandidates(
   command: string,
   cwd: string,
-  depth = 0,
+  options: ExtractOptions = {},
 ): Promise<string[]> {
+  const { depth = 0, pathExists = existsSync } = options;
   const seen = new Set<string>();
   const results: string[] = [];
 
   const addCandidate = async (
     token: string,
     forcePath = false,
+    commandName?: string,
+    commandArgs: string[] = [],
   ): Promise<void> => {
     if (!token || token.startsWith("-")) return;
     if (!forcePath && !maybePathLike(token)) return;
+    if (!forcePath && hasNonPathShape(token)) return;
+
+    // Suppression is skipped whenever the command could create the missing
+    // parent itself: known path-creating commands (looked up through wrappers
+    // such as `sudo` or `npx`) and interpreters running arbitrary programs.
+    const skipImplausible =
+      forcePath ||
+      commandCreatesPaths(commandName, commandArgs) ||
+      (commandName !== undefined && isInterpreterCommand(commandName));
 
     const expanded = await expandCandidate(token, cwd);
     for (const file of expanded) {
       const abs = resolve(cwd, expandHomePath(file));
+      // Only outside-workspace candidates are filtered: in-workspace paths are
+      // always allowed downstream, so noise there cannot cause a prompt.
+      if (
+        !skipImplausible &&
+        !isWithinBoundary(abs, cwd) &&
+        isImplausibleLocalPath(abs, pathExists)
+      ) {
+        continue;
+      }
       if (!seen.has(abs)) {
         seen.add(abs);
         results.push(abs);
@@ -62,19 +109,27 @@ export async function extractBashPathCandidates(
           if (arg.recurseShell) {
             if (depth >= MAX_SHELL_DEPTH) continue;
             pending.push(
-              extractBashPathCandidates(arg.token, cwd, depth + 1).then(
-                (nested) => {
-                  for (const abs of nested) {
-                    if (!seen.has(abs)) {
-                      seen.add(abs);
-                      results.push(abs);
-                    }
+              extractBashPathCandidates(arg.token, cwd, {
+                depth: depth + 1,
+                pathExists,
+              }).then((nested) => {
+                for (const abs of nested) {
+                  if (!seen.has(abs)) {
+                    seen.add(abs);
+                    results.push(abs);
                   }
-                },
-              ),
+                }
+              }),
             );
           } else {
-            pending.push(addCandidate(arg.token, arg.forcePath));
+            pending.push(
+              addCandidate(
+                arg.token,
+                arg.forcePath,
+                commandName,
+                words.slice(1),
+              ),
+            );
           }
         }
       } else {
@@ -99,11 +154,18 @@ export async function extractBashPathCandidates(
     await Promise.all(pending);
     return results;
   } catch {
-    // Fallback: regex tokenization
+    // Fallback: regex tokenization. The command name is unreliable here, so
+    // only shape rejection applies; existence suppression stays off to keep
+    // the fallback fail-safe (extra candidates, never fewer).
     const tokenRegex = /"([^"]+)"|'([^']+)'|`([^`]+)`|([^\s"'`<>|;&]+)/g;
     for (const match of command.matchAll(tokenRegex)) {
       const token = match[1] ?? match[2] ?? match[3] ?? match[4] ?? "";
-      if (token && !token.startsWith("-") && maybePathLike(token)) {
+      if (
+        token &&
+        !token.startsWith("-") &&
+        maybePathLike(token) &&
+        !hasNonPathShape(token)
+      ) {
         const expanded = await expandCandidate(token, cwd);
         for (const file of expanded) {
           const abs = resolve(cwd, expandHomePath(file));

--- a/src/shared/paths/bash-paths.ts
+++ b/src/shared/paths/bash-paths.ts
@@ -9,6 +9,7 @@ import {
 import {
   commandCreatesPaths,
   hasNonPathShape,
+  hasShellExpansion,
   isImplausibleLocalPath,
 } from "../../core/paths/plausibility";
 import { walkCommands, wordToString } from "../../core/shell/ast";
@@ -70,11 +71,14 @@ export async function extractBashPathCandidates(
     if (!forcePath && !maybePathLike(token)) return;
     if (!forcePath && hasNonPathShape(token)) return;
 
-    // Suppression is skipped whenever the command could create the missing
-    // parent itself: known path-creating commands (looked up through wrappers
-    // such as `sudo` or `npx`) and interpreters running arbitrary programs.
+    // Suppression is skipped whenever the filesystem cannot settle the
+    // question: the command creates missing parents itself (known
+    // path-creating commands, looked up through wrappers such as `sudo` or
+    // `npx`), the command runs an arbitrary program, or the token still
+    // contains an unexpanded shell reference.
     const skipImplausible =
       forcePath ||
+      hasShellExpansion(token) ||
       commandCreatesPaths(commandName, commandArgs) ||
       (commandName !== undefined && isInterpreterCommand(commandName));
 


### PR DESCRIPTION
## Problem

`extractBashPathCandidates` treats any argv token containing a separator as a path candidate. `classifyCommandArgs` special-cases a fixed list of commands and returns every token for the rest, so slash-bearing identifiers become outside-workspace paths and prompt:

```
ctx7 docs /websites/apisix "routes"       -> ['/websites/apisix']
gh pr view 12 --repo /aliou/pi-guardrails -> ['/aliou/pi-guardrails']
docker run -v /tmp:/tmp alpine            -> ['/tmp:/tmp']
curl https://example.com/a/b              -> [<cwd>/https:/example.com/a/b]
```

Every previous fix for this added another hardcoded classifier: #22 (dd), #32 (awk), #39 (`go test ./...`). #49/#50 and PRs #51/#52/#85 are the next iteration. The set of CLIs is unbounded, so enumeration does not terminate — and #51/#52/#85 arrived from three different contributors hitting the same bug.

## Approach

The false-positive class is token **shape**, not command **identity**. Two command-agnostic checks in `src/core/paths/plausibility.ts`:

1. `hasNonPathShape(token)` — rejects shapes that cannot be a local path: URL scheme, `user@host:` remote target, `...` package wildcard. Only patterns that are *never* a legal path qualify; a `docker -v /src:/dst` regex was deliberately left out because it is the one shape that can match a real file.
2. `isImplausibleLocalPath(abs, exists)` — drops a candidate when neither it nor its parent directory exists. Top-level entries (`/exfil`) and the root are never dropped.

Applied only to **outside-workspace** candidates. `checkPathAccess` allows everything inside the workspace, so in-workspace noise cannot produce a prompt and is not worth a stat call.

## Safety model

Extra candidates are noise; missing candidates are a bypass. Suppression is skipped whenever the filesystem cannot settle the question:

- `forcePath` tokens — redirect targets, `-o`/`-f`/`-File` values
- interpreters — the program can call `os.makedirs` itself (this is the #76 defense)
- commands that create missing parents — resolved through wrappers, plus a scan of the command's bare words, so `env -C /tmp mkdir`, `xargs -I {} mkdir` and `sudo /bin/mkdir` are all caught
- tokens holding an unexpanded shell reference — `$VAR`, `${VAR}`, `$(...)`, backticks

The last one is the principle from #84: a path you cannot resolve cannot be proven absent. Without it, `cat "$(pwd)/../../etc/shadow"` resolves to a missing directory and gets suppressed while the command reads a real file. Second commit fixes that.

Reads of existing secrets are structurally unaffected — `/etc/passwd`, `~/.ssh/id_rsa`, `~/.aws/credentials` all exist, so they are never suppressed. The design is also evasion-resistant in the obvious direction: creating `/exfil` first (itself never suppressed) makes the parent exist, which re-enables reporting for everything under it.

## Code removed

`classifyCommandArgs` goes from 10 special cases to 4. Deleted: `awk`, `sed`, `grep`-like, `jq`/`yq`, `go`. Kept, each for a reason no heuristic can recover:

| Kept | Why |
|---|---|
| `xargs` | runs a nested command, so argv must be re-classified as that command's (from #82) |
| interpreters | `recurseShell` + inline code scan; the #76 defense |
| `find` | expression grammar and shell punctuation; the #79 drive-root case |
| `cut`/`sort`/`tr` | the delimiter value is literally `/`, which exists, so no existence check can reject it |

No ctx7 entry, no wrapper registry, no config.

## Why not the config approach in #50/#52

`ignoredBashArgs` moves the enumeration treadmill from code into JSON — users still add a rule per CLI, after each false prompt. It also inverts the risk: an agent that can write `{"command":"cat","subcommands":["*"]}` into guardrails config has a general path-access bypass, which is the same failure family as #76. If per-command rules are wanted later, they should ship as curated built-in data, not agent-writable config.

## Tests

436 passing. `src/shared/paths/bash-paths.plausibility.test.ts` (46 cases) was written red first — 17 failures against the old code — then implemented. It uses memfs, already globally mocked in this repo, so it exercises the production `existsSync` path; `plausibility.test.ts` unit-tests the pure helpers with an injected prober.

Coverage: ctx7 in 8 invocation forms including nested `bash -c`; go package patterns; URLs, volume specs, remote targets; and the escape-attempt set — redirect targets, `mkdir -p`, `curl --create-dirs`, interpreter `os.makedirs`, wrapper options, the two-step create-then-write evasion, and a colon-bearing path that really exists.

Two tests from #82 were relaxed, both to in-workspace noise that cannot prompt:

- `xargs grep -l "a\|b"` — the pattern is now returned as a candidate and resolves under cwd on POSIX and Windows alike. The #79 assertion is rewritten to check what matters: no outside-workspace candidate is invented, and the `\` drive-root token is still gone.
- `sed`/`jq` script tokens are likewise kept as in-workspace noise.

## Not covered

#79 is fixed by #82 (already merged) — the drive root exists, so no plausibility check can reject it. #84 is complementary: it fixes the policies extractor (`extensions/guardrails/targets.ts`), this touches path-access (`src/shared/paths/bash-paths.ts`). Both are needed.

## Behaviour changes worth review

- `go run main.go` no longer yields a candidate. A bare filename has no separator, the same rule that already applies to `cat README.md`, and it resolves inside the workspace either way.
- `go -C /tmp test ./...` now surfaces `/tmp`. The old classifier hid it, but `go -C` really does operate there.

Closes #49
Closes #50
Supersedes #51
Supersedes #52
Supersedes #85
